### PR TITLE
feat(ci): add GHA build workflow and GoCD deploy pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Build and Push
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/getsentry/sentry-orbital:nightly
+            ghcr.io/getsentry/sentry-orbital:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/getsentry/sentry-orbital:nightly
+          cache-to: type=inline
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/getsentry/sentry-orbital

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,14 @@
-name: Build and Push
+name: Build
 
 on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
   build:
-    name: Build and push Docker image
+    name: Build and smoke test
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,17 +17,55 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GHCR
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          # Load into the local Docker daemon for the smoke test.
+          # On main pushes we also push to GHCR (see next step).
+          load: true
+          platforms: linux/amd64
+          tags: sentry-orbital:local
+          cache-from: type=registry,ref=ghcr.io/getsentry/sentry-orbital:nightly
+          cache-to: type=inline
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/getsentry/sentry-orbital
 
-      - name: Build and push
+      - name: Smoke test
+        run: |
+          docker run --rm -d \
+            --name orbital-smoke \
+            -p 7000:7000 \
+            sentry-orbital:local
+          # Wait for the container to be ready
+          for i in $(seq 1 10); do
+            if curl -sf http://localhost:7000/healthz; then
+              break
+            fi
+            echo "Waiting... ($i)"
+            sleep 1
+          done
+          # /healthz must return 200 with body "ok"
+          HEALTH=$(curl -sf http://localhost:7000/healthz)
+          [ "$HEALTH" = "ok" ] || (echo "healthz returned: $HEALTH" && exit 1)
+          # / must return 200 and contain the globe canvas
+          curl -sf http://localhost:7000/ | grep -q 'orbital' || (echo "index page missing expected content" && exit 1)
+          docker stop orbital-smoke
+
+      - name: Push to GHCR
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
Replaces the manual "build locally, push from local, deploy with kubectl" process with proper CI/CD using the same two-pipeline model as getsentry/getsentry.

## Changes

**`.github/workflows/build.yml`** — GHA build workflow
- Triggers on PRs (build + smoke test only) and pushes to `main` (build + smoke test + push to GHCR)
- Smoke test starts the container and verifies `/healthz` and `/` respond correctly
- Pushes to `ghcr.io/getsentry/sentry-orbital` with `:nightly` + `:<sha>` tags

**`gocd/templates/`** — GoCD deploy pipeline (image deploys)
- Watches `sentry-orbital/main` as a GoCD material
- `checks` stage waits for the GHA "Build and smoke test" check to pass
- `deploy-primary` stage runs `k8s-deploy` to patch the live k8s deployment with the new image `ghcr.io/getsentry/sentry-orbital:<git-sha>`
- US-only (same region exclusions as the ops-side k8s pipeline)

This is the same pattern as `deploy-getsentry-backend` — GoCD detects new commits, waits for CI, then directly patches k8s. No ops repo changes needed for image deploys.

## Related PRs

- **ops**: https://github.com/getsentry/ops/pull/19386 — k8s manifests use placeholder tag (`:_TAG_DOES_NOT_EXIST`), `orbital-k8s` pipeline handles config-only changes with `check-ongoing-deploy` enabled, IAM for both `deploy-to-orbital` and `deploy-to-orbital-k8s` SAs
- **devinfra-deployment-service**: https://github.com/getsentry/devinfra-deployment-service/pull/830 — registers both `orbital` (image deploy, this repo) and `orbital-k8s` (config deploy, ops repo)

## Deploy workflow (post-merge)

```
Push to main
  → GHA builds image, pushes ghcr.io/getsentry/sentry-orbital:<sha>
  → GoCD detects new commit on main
  → checks stage waits for GHA green
  → deploy-primary runs k8s-deploy to patch the live deployment
  → pods roll out with the new image
```

No ops repo changes needed. Ever.