### PR TITLE
feat(cd): add GoCD deploy pipeline for automated image deploys

### DIFF
--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+checks-githubactions-checkruns \
+  getsentry/sentry-orbital \
+  "${GO_REVISION_ORBITAL_REPO}" \
+  "Build and smoke test" \
+  --timeout-mins=15

--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -2,6 +2,6 @@
 set -euo pipefail
 checks-githubactions-checkruns \
   getsentry/sentry-orbital \
-  "${GO_REVISION_ORBITAL}" \
+  "${GO_REVISION_ORBITAL_REPO}" \
   "Build and smoke test" \
   --timeout-mins=15

--- a/gocd/templates/bash/check-github-runs.sh
+++ b/gocd/templates/bash/check-github-runs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -euo pipefail
 checks-githubactions-checkruns \
   getsentry/sentry-orbital \
-  "${GO_REVISION_ORBITAL_REPO}" \
+  "${GO_REVISION_ORBITAL}" \
   "Build and smoke test" \
   --timeout-mins=15

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -9,5 +9,5 @@ k8s-deploy \
   --type="deployment" \
   --label-selector="service=orbital" \
   --container-name="orbital" \
-  --image="ghcr.io/getsentry/sentry-orbital:${GO_REVISION_ORBITAL}" \
+  --image="ghcr.io/getsentry/sentry-orbital:${GO_REVISION_ORBITAL_REPO}" \
   --wait-timeout-mins=5

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -9,5 +9,5 @@ k8s-deploy \
   --type="deployment" \
   --label-selector="service=orbital" \
   --container-name="orbital" \
-  --image="ghcr.io/getsentry/sentry-orbital:${GO_REVISION_ORBITAL_REPO}" \
+  --image="ghcr.io/getsentry/sentry-orbital:${GO_REVISION_ORBITAL}" \
   --wait-timeout-mins=5

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
+
+/devinfra/scripts/get-cluster-credentials
+
+k8s-deploy \
+  --type="deployment" \
+  --label-selector="service=orbital" \
+  --container-name="orbital" \
+  --image="ghcr.io/getsentry/sentry-orbital:${GO_REVISION_ORBITAL_REPO}" \
+  --wait-timeout-mins=5

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "libs"
+        }
+      },
+      "version": "v2.18.0"
+    }
+  ],
+  "legacyImports": true
+}

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "libs"
+        }
+      },
+      "version": "3b7e3b151fb20d21d66c2f04d17a740ba0b09ac0",
+      "sum": "cgfkKWTz+bBKHa8WVji1v4Ke5JM3bTeMnqPtYZuy9VM="
+    }
+  ],
+  "legacyImports": false
+}

--- a/gocd/templates/orbital.jsonnet
+++ b/gocd/templates/orbital.jsonnet
@@ -1,0 +1,18 @@
+local orbital = import './pipelines/orbital.libsonnet';
+local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'orbital',
+  // Orbital is only deployed to US
+  exclude_regions: ['s4s', 's4s2', 'de', 'customer-1', 'customer-2', 'customer-4', 'customer-7'],
+  materials: {
+    orbital_repo: {
+      git: 'git@github.com:getsentry/sentry-orbital.git',
+      shallow_clone: true,
+      branch: 'main',
+      destination: 'sentry-orbital',
+    },
+  },
+};
+
+pipedream.render(pipedream_config, orbital)

--- a/gocd/templates/orbital.jsonnet
+++ b/gocd/templates/orbital.jsonnet
@@ -10,7 +10,7 @@ local pipedream_config = {
       git: 'git@github.com:getsentry/sentry-orbital.git',
       shallow_clone: true,
       branch: 'main',
-      destination: 'sentry-orbital',
+      destination: 'orbital',
     },
   },
 };

--- a/gocd/templates/orbital.jsonnet
+++ b/gocd/templates/orbital.jsonnet
@@ -10,7 +10,7 @@ local pipedream_config = {
       git: 'git@github.com:getsentry/sentry-orbital.git',
       shallow_clone: true,
       branch: 'main',
-      destination: 'orbital',
+      destination: 'sentry-orbital',
     },
   },
 };

--- a/gocd/templates/orbital.jsonnet
+++ b/gocd/templates/orbital.jsonnet
@@ -4,7 +4,7 @@ local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libso
 local pipedream_config = {
   name: 'orbital',
   // Orbital is only deployed to US
-  exclude_regions: ['s4s', 's4s2', 'de', 'customer-1', 'customer-2', 'customer-4', 'customer-7'],
+  include_regions: ['us'],
   materials: {
     orbital_repo: {
       git: 'git@github.com:getsentry/sentry-orbital.git',

--- a/gocd/templates/pipelines/orbital.libsonnet
+++ b/gocd/templates/pipelines/orbital.libsonnet
@@ -11,7 +11,7 @@ function(region) {
       git: 'git@github.com:getsentry/sentry-orbital.git',
       shallow_clone: true,
       branch: 'main',
-      destination: 'orbital',
+      destination: 'sentry-orbital',
     },
   },
   stages: [

--- a/gocd/templates/pipelines/orbital.libsonnet
+++ b/gocd/templates/pipelines/orbital.libsonnet
@@ -11,7 +11,7 @@ function(region) {
       git: 'git@github.com:getsentry/sentry-orbital.git',
       shallow_clone: true,
       branch: 'main',
-      destination: 'sentry-orbital',
+      destination: 'orbital',
     },
   },
   stages: [

--- a/gocd/templates/pipelines/orbital.libsonnet
+++ b/gocd/templates/pipelines/orbital.libsonnet
@@ -1,0 +1,44 @@
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
+
+function(region) {
+  environment_variables: {
+    GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+    SENTRY_REGION: region,
+  },
+  lock_behavior: 'unlockWhenFinished',
+  materials: {
+    orbital_repo: {
+      git: 'git@github.com:getsentry/sentry-orbital.git',
+      shallow_clone: true,
+      branch: 'main',
+      destination: 'sentry-orbital',
+    },
+  },
+  stages: [
+    {
+      checks: {
+        jobs: {
+          'ci-orbital': {
+            elastic_profile_id: 'orbital',
+            tasks: [
+              gocdtasks.script(importstr '../bash/check-github-runs.sh'),
+            ],
+          },
+        },
+      },
+    },
+    {
+      'deploy-primary': {
+        fetch_materials: true,
+        jobs: {
+          'deploy-orbital': {
+            elastic_profile_id: 'orbital',
+            tasks: [
+              gocdtasks.script(importstr '../bash/deploy.sh'),
+            ],
+          },
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
Follow-up to #9 (merged). Adds the GoCD deploy pipeline so image deploys happen automatically — no ops repo changes needed.

## Changes

**`gocd/templates/orbital.jsonnet`** — top-level pipeline definition
- Watches `sentry-orbital/main` as a GoCD material
- US-only (excludes s4s, s4s2, de, customer-*)
- Uses `pipedream.render()` for standard multi-region fanout

**`gocd/templates/pipelines/orbital.libsonnet`** — pipeline stages
- `checks` — waits for GHA "Build and smoke test" check to pass via `checks-githubactions-checkruns`
- `deploy-primary` — runs `k8s-deploy` to patch the live k8s deployment with `ghcr.io/getsentry/sentry-orbital:<git-sha>`

**`gocd/templates/bash/`** — shell scripts
- `check-github-runs.sh` — polls GHA check status for the commit
- `deploy.sh` — gets cluster credentials, runs `k8s-deploy` with label selector `service=orbital`

**`gocd/templates/jsonnetfile.json` + lock** — pins `gocd-jsonnet` v2.18.0 (same as getsentry)

## How it works

Same pattern as `deploy-getsentry-backend`:

```
Push to master
  → GHA builds image → pushes ghcr.io/getsentry/sentry-orbital:<sha>
  → GoCD detects new commit (material watch)
  → checks stage waits for GHA green
  → deploy-primary runs k8s-deploy → patches live deployment
  → pods roll out with the new image
```

## Related PRs

- **ops**: https://github.com/getsentry/ops/pull/19386 — placeholder image tag + `check-ongoing-deploy` + IAM for `deploy-to-orbital` SA
- **devinfra-deployment-service**: https://github.com/getsentry/devinfra-deployment-service/pull/830 — registers `orbital` deploy config pointing at this repo