### PR TITLE
fix(gocd): use master branch instead of main

### DIFF
--- a/gocd/templates/orbital.jsonnet
+++ b/gocd/templates/orbital.jsonnet
@@ -9,7 +9,7 @@ local pipedream_config = {
     orbital_repo: {
       git: 'git@github.com:getsentry/sentry-orbital.git',
       shallow_clone: true,
-      branch: 'main',
+      branch: 'master',
       destination: 'sentry-orbital',
     },
   },

--- a/gocd/templates/pipelines/orbital.libsonnet
+++ b/gocd/templates/pipelines/orbital.libsonnet
@@ -10,7 +10,7 @@ function(region) {
     orbital_repo: {
       git: 'git@github.com:getsentry/sentry-orbital.git',
       shallow_clone: true,
-      branch: 'main',
+      branch: 'master',
       destination: 'sentry-orbital',
     },
   },


### PR DESCRIPTION
The `sentry-orbital` repo uses `master` as its default branch, not `main`. GoCD pipelines are failing with:

```
Modification check failed for material: URL: git@github.com:getsentry/sentry-orbital.git, Branch: main
fatal: Remote branch main not found in upstream origin
```

Affected pipelines: `deploy-orbital-customer-1`, `deploy-orbital-customer-2`, `deploy-orbital-customer-4`, `deploy-orbital-customer-7`, `deploy-orbital-de`, `deploy-orbital-s4s`, `deploy-orbital-s4s2`, `deploy-orbital-us`.

This PR fixes the branch reference from `main` to `master` in both:
- `gocd/templates/orbital.jsonnet` (pipedream config material)
- `gocd/templates/pipelines/orbital.libsonnet` (pipeline material)