### PR TITLE
feat(orbital): Responsive mobile layout and fix globe zoom on first load

### DIFF
--- a/static/orbital.css
+++ b/static/orbital.css
@@ -281,3 +281,69 @@ header {
   z-index: 10;
   pointer-events: none;
 }
+
+/* ── Mobile responsive ───────────────────────────────────────── */
+
+@media (max-width: 600px) {
+  #ui {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  header {
+    padding: 10px 14px;
+    border-radius: 10px;
+  }
+
+  .brand-wordmark {
+    height: 16px;
+  }
+
+  .brand-live {
+    font-size: 9px;
+    letter-spacing: 1.5px;
+    padding-left: 10px;
+    gap: 5px;
+  }
+
+  .stat span {
+    font-size: 16px;
+  }
+
+  .stat label {
+    font-size: 8px;
+  }
+
+  /* Move feed to a slim bar along the bottom edge */
+  #event-feed {
+    position: fixed;
+    bottom: 28px;
+    left: 12px;
+    right: 12px;
+    width: auto;
+    border-radius: 10px;
+  }
+
+  #feed-list {
+    max-height: 140px;
+    overflow: hidden;
+  }
+
+  #feed-list li {
+    padding: 6px 12px;
+  }
+
+  .feed-platform {
+    font-size: 11px;
+    min-width: 60px;
+  }
+
+  .feed-location {
+    font-size: 10px;
+  }
+
+  #footer {
+    font-size: 9px;
+    padding: 8px;
+  }
+}

--- a/static/orbital.js
+++ b/static/orbital.js
@@ -478,6 +478,7 @@ window.addEventListener('resize', () => {
   renderer.setSize(window.innerWidth, window.innerHeight);
   camera.position.z = mobile ? 8.0 : 5.6;
   camera.position.y = mobile ? -0.65 : 0;
+  controls.update();
 });
 
 // ── Animation loop ────────────────────────────────────────────────────────────

--- a/static/orbital.js
+++ b/static/orbital.js
@@ -81,7 +81,8 @@ const scene  = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(
   45, window.innerWidth / window.innerHeight, 0.1, 1000
 );
-camera.position.z = 2.8;
+camera.position.z = window.innerWidth <= 600 ? 8.0 : 5.6;
+camera.position.y = window.innerWidth <= 600 ? -0.65 : 0;
 
 // ── Stars ────────────────────────────────────────────────────────────────────
 
@@ -168,7 +169,7 @@ controls.enableDamping   = true;
 controls.dampingFactor   = 0.05;
 controls.enablePan       = false;
 controls.minDistance     = 1.4;
-controls.maxDistance     = 6;
+controls.maxDistance     = 10;
 controls.autoRotate      = true;
 controls.autoRotateSpeed = 0.35;
 
@@ -471,9 +472,12 @@ document.addEventListener('visibilitychange', () => {
 // ── Resize ────────────────────────────────────────────────────────────────────
 
 window.addEventListener('resize', () => {
+  const mobile = window.innerWidth <= 600;
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
+  camera.position.z = mobile ? 8.0 : 5.6;
+  camera.position.y = mobile ? -0.65 : 0;
 });
 
 // ── Animation loop ────────────────────────────────────────────────────────────

--- a/static/orbital.js
+++ b/static/orbital.js
@@ -476,8 +476,7 @@ window.addEventListener('resize', () => {
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
-  camera.position.z = mobile ? 8.0 : 5.6;
-  camera.position.y = mobile ? -0.65 : 0;
+  camera.position.set(0, mobile ? -0.65 : 0, mobile ? 8.0 : 5.6);
   controls.update();
 });
 

--- a/static/orbital.js
+++ b/static/orbital.js
@@ -473,11 +473,13 @@ document.addEventListener('visibilitychange', () => {
 // ── Resize ────────────────────────────────────────────────────────────────────
 
 window.addEventListener('resize', () => {
-  const mobile = mobileQuery.matches;
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);
-  camera.position.set(0, mobile ? -0.65 : 0, mobile ? 8.0 : 5.6);
+});
+
+mobileQuery.addEventListener('change', e => {
+  camera.position.set(0, e.matches ? -0.65 : 0, e.matches ? 8.0 : 5.6);
   controls.update();
 });
 

--- a/static/orbital.js
+++ b/static/orbital.js
@@ -81,8 +81,9 @@ const scene  = new THREE.Scene();
 const camera = new THREE.PerspectiveCamera(
   45, window.innerWidth / window.innerHeight, 0.1, 1000
 );
-camera.position.z = window.innerWidth <= 600 ? 8.0 : 5.6;
-camera.position.y = window.innerWidth <= 600 ? -0.65 : 0;
+const mobileQuery = window.matchMedia('(max-width: 600px)');
+camera.position.z = mobileQuery.matches ? 8.0 : 5.6;
+camera.position.y = mobileQuery.matches ? -0.65 : 0;
 
 // ── Stars ────────────────────────────────────────────────────────────────────
 
@@ -472,7 +473,7 @@ document.addEventListener('visibilitychange', () => {
 // ── Resize ────────────────────────────────────────────────────────────────────
 
 window.addEventListener('resize', () => {
-  const mobile = window.innerWidth <= 600;
+  const mobile = mobileQuery.matches;
   camera.aspect = window.innerWidth / window.innerHeight;
   camera.updateProjectionMatrix();
   renderer.setSize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary

- Add CSS media query (≤600px) to reflow the event feed as a full-width bottom bar and compact the header/stats for narrow screens — the globe is no longer obscured by UI panels on mobile
- Set initial camera distance based on viewport width so the globe fits fully on screen at first load instead of being zoomed in (mobile: z=8, desktop: z=5.6)
- Offset camera y on mobile to position the globe ~20% higher, giving clearance above the event feed panel
- Raise OrbitControls `maxDistance` to 10 to accommodate the wider zoom range

## Test plan

- [ ] Open on desktop — globe should appear smaller/more zoomed out than before
- [ ] Open in Chrome DevTools mobile emulation (≤600px width) — globe should be fully visible and positioned in the upper portion of the screen
- [ ] Event feed should appear as a compact full-width bar at the bottom on mobile
- [ ] Rotating the globe and pinch-to-zoom should still work on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)