### PR TITLE
feat: add GoCD pipeline for auto-deploy on push to master

### DIFF
--- a/gocd/templates/bash/check-github.sh
+++ b/gocd/templates/bash/check-github.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+checks-githubactions-checkruns \
+  getsentry/sentry-orbital \
+  "${GO_REVISION_ORBITAL_REPO}" \
+  "Build and smoke test"

--- a/gocd/templates/bash/deploy.sh
+++ b/gocd/templates/bash/deploy.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+eval "$(regions-project-env-vars --region="${SENTRY_REGION}")"
+
+/devinfra/scripts/get-cluster-credentials \
+  && k8s-deploy \
+  --label-selector="service=orbital" \
+  --image="ghcr.io/getsentry/sentry-orbital:${GO_REVISION_ORBITAL_REPO}" \
+  --container-name="orbital"

--- a/gocd/templates/jsonnetfile.json
+++ b/gocd/templates/jsonnetfile.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "libs"
+        }
+      },
+      "version": "v2.19.0"
+    }
+  ],
+  "legacyImports": true
+}

--- a/gocd/templates/jsonnetfile.lock.json
+++ b/gocd/templates/jsonnetfile.lock.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/getsentry/gocd-jsonnet.git",
+          "subdir": "libs"
+        }
+      },
+      "version": "56cc4d91cbaac4569b37b4911998b48c2f9c2ac4",
+      "sum": "J0D//go/146qfReWFTTL5xWWCVlkTjqhnALYPH4Z9rE="
+    }
+  ],
+  "legacyImports": false
+}

--- a/gocd/templates/orbital.jsonnet
+++ b/gocd/templates/orbital.jsonnet
@@ -1,0 +1,32 @@
+local orbital = import './pipelines/orbital.libsonnet';
+local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libsonnet';
+
+local pipedream_config = {
+  name: 'orbital',
+  auto_deploy: true,
+  // US-only
+  exclude_regions: [
+    's4s',
+    's4s2',
+    'de',
+    'customer-1',
+    'customer-2',
+    'customer-4',
+    'customer-7',
+  ],
+  materials: {
+    orbital_repo: {
+      git: 'git@github.com:getsentry/sentry-orbital.git',
+      shallow_clone: false,
+      branch: 'master',
+      destination: 'orbital',
+    },
+  },
+  rollback: {
+    material_name: 'orbital_repo',
+    stage: 'deploy-primary',
+    elastic_profile_id: 'orbital',
+  },
+};
+
+pipedream.render(pipedream_config, orbital)

--- a/gocd/templates/pipelines/orbital.libsonnet
+++ b/gocd/templates/pipelines/orbital.libsonnet
@@ -1,0 +1,49 @@
+local gocdtasks = import 'github.com/getsentry/gocd-jsonnet/libs/gocd-tasks.libsonnet';
+
+function(region) {
+  materials: {
+    orbital_repo: {
+      git: 'git@github.com:getsentry/sentry-orbital.git',
+      shallow_clone: false,
+      branch: 'master',
+      destination: 'orbital',
+    },
+  },
+  lock_behavior: 'unlockWhenFinished',
+  stages: [
+    {
+      checks: {
+        fetch_materials: true,
+        environment_variables: {
+          GITHUB_TOKEN: '{{SECRET:[devinfra-github][token]}}',
+        },
+        jobs: {
+          check: {
+            timeout: 1200,
+            elastic_profile_id: 'orbital',
+            tasks: [
+              gocdtasks.script(importstr '../bash/check-github.sh'),
+            ],
+          },
+        },
+      },
+    },
+    {
+      'deploy-primary': {
+        fetch_materials: true,
+        environment_variables: {
+          SENTRY_REGION: region,
+        },
+        jobs: {
+          deploy: {
+            timeout: 1200,
+            elastic_profile_id: 'orbital',
+            tasks: [
+              gocdtasks.script(importstr '../bash/deploy.sh'),
+            ],
+          },
+        },
+      },
+    },
+  ],
+}


### PR DESCRIPTION
## Summary

Adds GoCD pipeline templates following the [seer pattern](https://github.com/getsentry/seer/tree/main/gocd/templates) for auto-deploy on push to master.

### What's added
- `gocd/templates/orbital.jsonnet` — pipedream config with `auto_deploy: true`, materials watching `sentry-orbital` master, US-only deploy (`exclude_regions` for all non-US regions)
- `gocd/templates/pipelines/orbital.libsonnet` — 2-stage pipeline: check GH Actions → deploy
- `gocd/templates/bash/check-github.sh` — verifies 'Build and smoke test' job passed for the commit
- `gocd/templates/bash/deploy.sh` — `k8s-deploy` with `ghcr.io/getsentry/sentry-orbital:${GO_REVISION_ORBITAL_REPO}`
- `gocd/templates/jsonnetfile.json` + lock — gocd-jsonnet v2.19.0

### Deploy flow
```
push to master
  → GH Actions builds & pushes :nightly + :sha to GHCR
  → GoCD detects new commit on master (auto_deploy: true)
  → checks stage: waits for 'Build and smoke test' GH Actions job to pass
  → deploy-primary stage: k8s-deploy with image tagged by commit SHA
```

### Companion PRs
- devinfra-deployment-service: update `orbital-k8s` deploy-config to point at `sentry-orbital` repo (PR forthcoming)
- ops: remove the old `orbital-k8s.jsonnet` + GH Actions workflow (PR forthcoming)