### PR TITLE
fix(sentry): Disable SendDefaultPII to prevent capturing user data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 orbital
+orbital_bin
 

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func main() {
 		Dsn:              "https://da9a4372645d168eff259433fb2403c9@o1.ingest.us.sentry.io/4510957955514368",
 		EnableTracing:    true,
 		TracesSampleRate: 1.0,
-		SendDefaultPII:   true,
+		SendDefaultPII:   false,
 	}); err != nil {
 		log.Fatalf("sentry.Init: %s", err)
 	}


### PR DESCRIPTION
Disable `SendDefaultPII` in the Sentry Go SDK initialization to prevent capturing IP addresses and other personally identifiable information in error reports.

This was surfaced during a Sentry setup audit — the flag was previously set to `true` without a documented reason. Defaulting to `false` is the safer and more privacy-respecting default.