### PR TITLE
fix(gocd): use orbital-k8s for pipeline group and elastic profile

### DIFF
--- a/gocd/templates/orbital.jsonnet
+++ b/gocd/templates/orbital.jsonnet
@@ -2,7 +2,7 @@ local orbital = import './pipelines/orbital.libsonnet';
 local pipedream = import 'github.com/getsentry/gocd-jsonnet/libs/pipedream.libsonnet';
 
 local pipedream_config = {
-  name: 'orbital',
+  name: 'orbital-k8s',
   auto_deploy: true,
   // US-only
   exclude_regions: [
@@ -25,7 +25,7 @@ local pipedream_config = {
   rollback: {
     material_name: 'orbital_repo',
     stage: 'deploy-primary',
-    elastic_profile_id: 'orbital',
+    elastic_profile_id: 'orbital-k8s',
   },
 };
 

--- a/gocd/templates/pipelines/orbital.libsonnet
+++ b/gocd/templates/pipelines/orbital.libsonnet
@@ -20,7 +20,7 @@ function(region) {
         jobs: {
           check: {
             timeout: 1200,
-            elastic_profile_id: 'orbital',
+            elastic_profile_id: 'orbital-k8s',
             tasks: [
               gocdtasks.script(importstr '../bash/check-github.sh'),
             ],
@@ -37,7 +37,7 @@ function(region) {
         jobs: {
           deploy: {
             timeout: 1200,
-            elastic_profile_id: 'orbital',
+            elastic_profile_id: 'orbital-k8s',
             tasks: [
               gocdtasks.script(importstr '../bash/deploy.sh'),
             ],


### PR DESCRIPTION
## Summary
- Fixes GoCD config repo validation errors by updating pipeline configuration to match server rules
- Changes pipeline group name from `orbital` to `orbital-k8s`
- Changes `elastic_profile_id` from `orbital` to `orbital-k8s` (in 3 places)

## Problem
The GoCD config repository was failing with these errors:
```
I. Rule Validation Errors: 
   1. Not allowed to refer to pipeline group 'orbital'. Check the 'Rules' of this config repository.

II. Config Validation Errors: 
   1. No profile defined corresponding to profile_id 'orbital'
```

## Solution
The GoCD server rules only allow:
- Pipeline Group: `orbital-k8s`
- Environment: `orbital-k8s*`

Updated the pipeline configuration to use `orbital-k8s` instead of `orbital` to match these rules.