### PR TITLE
feat(frontend): add globe drag, pause shortcut, and shooting stars

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,9 @@ import { useCallback } from "react";
 import { Toaster, toast } from "sonner";
 import { CobeGlobe } from "./components/cobe-globe";
 import { LiveFeed } from "./components/live-feed";
+import { PauseToast } from "./components/pause-toast";
 import { SeerToast } from "./components/seer-toast";
+import { ShootingStars } from "./components/shooting-stars";
 import { useEventStream } from "./hooks/use-event-stream";
 
 const currentYear = new Date().getFullYear();
@@ -36,11 +38,30 @@ function App() {
     );
   }, []);
 
+  const onPauseToggle = useCallback((isPaused: boolean) => {
+    toast.custom(
+      () => <PauseToast isPaused={isPaused} />,
+      {
+        id: "pause-toast",
+        duration: 2000,
+        unstyled: true,
+        classNames: {
+          toast: "!border-0 !bg-transparent !p-0 !shadow-none",
+        },
+      },
+    );
+  }, []);
+
   return (
     <div className="app-shell">
+      <ShootingStars />
       <div className="orbital-glow" />
       <div className="globe-wrap">
-        <CobeGlobe markers={markers} onSeerClick={onSeerClick} />
+        <CobeGlobe 
+          markers={markers} 
+          onSeerClick={onSeerClick}
+          onPauseToggle={onPauseToggle}
+        />
       </div>
 
       <main className="pointer-events-none absolute inset-0 flex flex-col justify-between p-4">

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -67,11 +67,18 @@ function App() {
       <main className="pointer-events-none absolute inset-0 flex flex-col justify-between p-4">
         <header className="pointer-events-auto flex items-center justify-between gap-2 rounded-xl border border-white/15 bg-gradient-to-b from-[#0b0914]/65 to-[#0b0914]/45 px-3.5 py-2.5 backdrop-blur-xl">
           <div className="flex min-w-0 items-center gap-2.5">
-            <img
-              src="/logo.svg"
-              alt="Sentry"
-              className="h-auto w-[clamp(68px,18vw,104px)] shrink-0 opacity-95"
-            />
+            <a
+              href="https://sentry.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0"
+            >
+              <img
+                src="/logo.svg"
+                alt="Sentry"
+                className="h-auto w-[clamp(68px,18vw,104px)] opacity-95 transition-opacity hover:opacity-100"
+              />
+            </a>
             <span
               className="h-5 w-px shrink-0 bg-white/20"
               aria-hidden="true"

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -6,18 +6,25 @@ import type { MarkerPoint } from "../types";
 type Props = {
   markers: MarkerPoint[];
   onSeerClick?: () => void;
+  onPauseToggle?: (isPaused: boolean) => void;
 };
 
 const GLOBE_R = 0.8;
 const MARKER_ELEVATION = 0.05;
 const GLOBE_THETA = 0.28;
+const GLOBE_THETA_MIN = -0.6;
+const GLOBE_THETA_MAX = 1.0;
 const GLOBE_AUTO_ROTATE_SPEED = 0.00145;
 const GLOBE_MARKER_SIZE = 0.02;
 const GLOBE_MAP_BRIGHTNESS = 5;
 const GLOBE_BASE_COLOR: [number, number, number] = [0.34, 0.24, 0.56];
 const POINTER_VELOCITY_DAMPING = 0.92;
+const POINTER_VELOCITY_DAMPING_Y = 0.88;
 const POINTER_VELOCITY_FACTOR = 0.0007;
+const POINTER_VELOCITY_FACTOR_Y = 0.0005;
 const POINTER_ROTATION_FACTOR = 0.0035;
+const POINTER_ROTATION_FACTOR_Y = 0.002;
+const THETA_RETURN_SPEED = 0.002;
 const UFO_LATITUDE_MIN = -32;
 const UFO_LATITUDE_MAX = 32;
 const UFO_LATITUDE_SMOOTHING = 0.028;
@@ -143,10 +150,11 @@ function placePulseElement(
   element.style.filter = projected.visible ? "none" : "blur(3px)";
 }
 
-export function CobeGlobe({ markers, onSeerClick }: Props) {
+export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const markersRef = useRef<MarkerPoint[]>(markers);
   const onSeerClickRef = useRef(onSeerClick);
+  const onPauseToggleRef = useRef(onPauseToggle);
   const pulsesDirtyRef = useRef(true);
   const haptics = useHaptics();
   const hapticsRef = useRef(haptics);
@@ -161,6 +169,10 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
   }, [onSeerClick]);
 
   useEffect(() => {
+    onPauseToggleRef.current = onPauseToggle;
+  }, [onPauseToggle]);
+
+  useEffect(() => {
     hapticsRef.current = haptics;
   }, [haptics]);
 
@@ -171,6 +183,7 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
     }
 
     let phi = 0;
+    let theta = GLOBE_THETA;
     const viewport: ViewportState = {
       width: 0,
       height: 0,
@@ -180,8 +193,11 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
       canvasHeight: 0,
     };
     let pointerX = 0;
+    let pointerY = 0;
     let pointerDown = false;
-    let velocity = 0;
+    let velocityX = 0;
+    let velocityY = 0;
+    let isPaused = false;
 
     const wrapper = canvas.parentElement;
     if (!wrapper) {
@@ -254,14 +270,27 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
       }
 
       if (!pointerDown) {
-        velocity *= POINTER_VELOCITY_DAMPING;
-        phi += GLOBE_AUTO_ROTATE_SPEED + velocity;
+        // Apply momentum with damping
+        velocityX *= POINTER_VELOCITY_DAMPING;
+        velocityY *= POINTER_VELOCITY_DAMPING_Y;
+        
+        // Only auto-rotate when not paused
+        const autoRotate = isPaused ? 0 : GLOBE_AUTO_ROTATE_SPEED;
+        phi += autoRotate + velocityX;
+        theta = Math.max(GLOBE_THETA_MIN, Math.min(GLOBE_THETA_MAX, theta + velocityY));
+        
+        // Slowly return theta to default when not dragging
+        const thetaDiff = GLOBE_THETA - theta;
+        if (Math.abs(thetaDiff) > 0.001) {
+          theta += thetaDiff * THETA_RETURN_SPEED * deltaMs;
+        }
       }
 
       globe.update({
         width: viewport.width,
         height: viewport.height,
         phi,
+        theta,
         markers: markersRef.current.map((marker) => ({
           location: [marker.lat, marker.lng] as [number, number],
           size: GLOBE_MARKER_SIZE,
@@ -282,7 +311,7 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
           marker.lat,
           marker.lng,
           phi,
-          GLOBE_THETA,
+          theta,
           aspect,
         );
         placePulseElement(el, projected, viewport);
@@ -303,7 +332,7 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
         ufoLat,
         ufoLng,
         phi,
-        GLOBE_THETA,
+        theta,
         aspect,
       );
       placePulseElement(ufoEl, ufoProjected, viewport);
@@ -316,6 +345,7 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
     const onPointerDown = (event: PointerEvent) => {
       pointerDown = true;
       pointerX = event.clientX;
+      pointerY = event.clientY;
       canvas.style.cursor = "grabbing";
     };
 
@@ -329,10 +359,18 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
         return;
       }
 
-      const delta = event.clientX - pointerX;
+      const deltaX = event.clientX - pointerX;
+      const deltaY = event.clientY - pointerY;
       pointerX = event.clientX;
-      velocity = delta * POINTER_VELOCITY_FACTOR;
-      phi += delta * POINTER_ROTATION_FACTOR;
+      pointerY = event.clientY;
+      
+      // Horizontal rotation (phi)
+      velocityX = deltaX * POINTER_VELOCITY_FACTOR;
+      phi += deltaX * POINTER_ROTATION_FACTOR;
+      
+      // Vertical tilt (theta) - clamped to prevent flipping
+      velocityY = deltaY * POINTER_VELOCITY_FACTOR_Y;
+      theta = Math.max(GLOBE_THETA_MIN, Math.min(GLOBE_THETA_MAX, theta + deltaY * POINTER_ROTATION_FACTOR_Y));
     };
 
     const onSeerImageClick = (event: MouseEvent) => {
@@ -352,6 +390,20 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
       ufoImage?.classList.remove("ufo-seer--wiggle");
     };
 
+    const onKeyDown = (event: KeyboardEvent) => {
+      // Ignore if user is typing in an input
+      if (event.target instanceof HTMLInputElement || event.target instanceof HTMLTextAreaElement) {
+        return;
+      }
+
+      if (event.code === "Space") {
+        event.preventDefault();
+        isPaused = !isPaused;
+        onPauseToggleRef.current?.(isPaused);
+        void hapticsRef.current?.trigger("nudge");
+      }
+    };
+
     canvas.style.cursor = "grab";
     canvas.style.touchAction = "none";
     ufoImage?.addEventListener("click", onSeerImageClick);
@@ -359,12 +411,14 @@ export function CobeGlobe({ markers, onSeerClick }: Props) {
     canvas.addEventListener("pointerdown", onPointerDown);
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("keydown", onKeyDown);
 
     return () => {
       resizeObserver.disconnect();
       canvas.removeEventListener("pointerdown", onPointerDown);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("keydown", onKeyDown);
       ufoImage?.removeEventListener("click", onSeerImageClick);
       ufoImage?.removeEventListener("animationend", onSeerAnimationEnd);
       window.cancelAnimationFrame(frame);

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -14,7 +14,7 @@ const MARKER_ELEVATION = 0.05;
 const GLOBE_THETA = 0.28;
 const GLOBE_THETA_MIN = -0.6;
 const GLOBE_THETA_MAX = 1.0;
-const GLOBE_AUTO_ROTATE_SPEED = 0.00145;
+const GLOBE_AUTO_ROTATE_SPEED = 0.000087; // radians per millisecond
 const GLOBE_MARKER_SIZE = 0.02;
 const GLOBE_MAP_BRIGHTNESS = 5;
 const GLOBE_BASE_COLOR: [number, number, number] = [0.34, 0.24, 0.56];
@@ -270,12 +270,14 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
       }
 
       if (!pointerDown) {
-        // Apply momentum with damping
-        velocityX *= POINTER_VELOCITY_DAMPING;
-        velocityY *= POINTER_VELOCITY_DAMPING_Y;
+        // Apply momentum with time-based damping (exponential decay)
+        const dampFactorX = Math.pow(POINTER_VELOCITY_DAMPING, deltaMs / 16.67);
+        const dampFactorY = Math.pow(POINTER_VELOCITY_DAMPING_Y, deltaMs / 16.67);
+        velocityX *= dampFactorX;
+        velocityY *= dampFactorY;
         
-        // Only auto-rotate when not paused
-        const autoRotate = isPaused ? 0 : GLOBE_AUTO_ROTATE_SPEED;
+        // Only auto-rotate when not paused (time-based)
+        const autoRotate = isPaused ? 0 : GLOBE_AUTO_ROTATE_SPEED * deltaMs;
         phi += autoRotate + velocityX;
         theta = Math.max(GLOBE_THETA_MIN, Math.min(GLOBE_THETA_MAX, theta + velocityY));
         

--- a/frontend/src/components/pause-toast.tsx
+++ b/frontend/src/components/pause-toast.tsx
@@ -1,0 +1,43 @@
+type PauseToastProps = {
+  isPaused: boolean;
+};
+
+export function PauseToast({ isPaused }: PauseToastProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-[#a889ff]/40 bg-[linear-gradient(135deg,rgba(18,12,32,0.95),rgba(30,18,52,0.95))] px-4 py-3 text-[#ece8fa] shadow-[0_12px_40px_rgba(7,4,14,0.7)] backdrop-blur-xl">
+      <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#b896ff]/20">
+        {isPaused ? (
+          <svg
+            className="h-5 w-5 text-[#b896ff]"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <rect x="6" y="4" width="4" height="16" rx="1" />
+            <rect x="14" y="4" width="4" height="16" rx="1" />
+          </svg>
+        ) : (
+          <svg
+            className="h-5 w-5 text-[#b896ff]"
+            fill="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        )}
+      </div>
+      
+      <div className="flex flex-col gap-0.5">
+        <span className="text-sm font-medium">
+          {isPaused ? "Rotation paused" : "Rotation resumed"}
+        </span>
+        <span className="flex items-center gap-1.5 text-[0.7rem] text-[#c8c0dc]">
+          Press
+          <kbd className="inline-flex h-5 min-w-[2rem] items-center justify-center rounded border border-[#a889ff]/30 bg-[#a889ff]/10 px-1.5 text-[0.65rem] font-medium text-[#d4c8f5]">
+            Space
+          </kbd>
+          to {isPaused ? "resume" : "pause"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/shooting-stars.tsx
+++ b/frontend/src/components/shooting-stars.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+
+type ShootingStar = {
+  id: string;
+  startX: number;
+  startY: number;
+  angle: number;
+  duration: number;
+};
+
+const SPAWN_INTERVAL_MIN = 8000;
+const SPAWN_INTERVAL_MAX = 15000;
+const DURATION_MIN = 1200;
+const DURATION_MAX = 2200;
+const MAX_STARS = 2;
+
+function randomRange(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+function createStar(): ShootingStar {
+  // Stars start from top or left edges, travel diagonally down-right
+  const fromTop = Math.random() > 0.4;
+  const startX = fromTop ? randomRange(5, 65) : randomRange(-5, 15);
+  const startY = fromTop ? randomRange(-5, 5) : randomRange(5, 45);
+  
+  return {
+    id: crypto.randomUUID(),
+    startX,
+    startY,
+    angle: randomRange(25, 50), // Diagonal down-right direction
+    duration: randomRange(DURATION_MIN, DURATION_MAX),
+  };
+}
+
+export function ShootingStars() {
+  const [stars, setStars] = useState<ShootingStar[]>([]);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout>;
+    
+    const spawnStar = () => {
+      setStars((current) => {
+        if (current.length >= MAX_STARS) {
+          return current;
+        }
+        return [...current, createStar()];
+      });
+      
+      // Schedule next spawn
+      timeout = setTimeout(spawnStar, randomRange(SPAWN_INTERVAL_MIN, SPAWN_INTERVAL_MAX));
+    };
+
+    // Initial spawn after a short delay
+    timeout = setTimeout(spawnStar, randomRange(3000, 6000));
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  const removeStar = (id: string) => {
+    setStars((current) => current.filter((star) => star.id !== id));
+  };
+
+  return (
+    <div className="shooting-stars-container">
+      {stars.map((star) => (
+        <div
+          key={star.id}
+          className="shooting-star"
+          style={{
+            left: `${star.startX}%`,
+            top: `${star.startY}%`,
+            "--angle": `${star.angle}deg`,
+            "--duration": `${star.duration}ms`,
+          } as React.CSSProperties}
+          onAnimationEnd={() => removeStar(star.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/shooting-stars.tsx
+++ b/frontend/src/components/shooting-stars.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { generateUUID } from "../utils";
 
 type ShootingStar = {
   id: string;
@@ -25,7 +26,7 @@ function createStar(): ShootingStar {
   const startY = fromTop ? randomRange(-5, 5) : randomRange(5, 45);
   
   return {
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     startX,
     startY,
     angle: randomRange(25, 50), // Diagonal down-right direction

--- a/frontend/src/hooks/use-event-stream.ts
+++ b/frontend/src/hooks/use-event-stream.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { stream } from "fetch-event-stream";
 import type { FeedItem, MarkerPoint, OrbitalEvent } from "../types";
+import { generateUUID } from "../utils";
 
 const PLATFORM_COLORS: Record<string, [number, number, number]> = {
   javascript: [0.76, 0.38, 1],
@@ -30,7 +31,7 @@ const FEED_RATE_MS = 320;
 const STATS_INTERVAL_MS = 1000;
 
 function toMarker(event: OrbitalEvent): MarkerPoint {
-  const markerId = crypto.randomUUID();
+  const markerId = generateUUID();
 
   return {
     id: markerId,
@@ -43,7 +44,7 @@ function toMarker(event: OrbitalEvent): MarkerPoint {
 
 function toFeed(event: OrbitalEvent): FeedItem {
   return {
-    id: crypto.randomUUID(),
+    id: generateUUID(),
     platform: event.platform,
     lat: event.lat,
     lng: event.lng,

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -266,3 +266,60 @@ body::after {
     margin-bottom: calc(1rem + env(safe-area-inset-bottom));
   }
 }
+
+/* Shooting Stars */
+.shooting-stars-container {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.shooting-star {
+  position: absolute;
+  width: 100px;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.4) 30%,
+    rgba(192, 180, 255, 0.8) 60%,
+    rgba(255, 255, 255, 1) 100%
+  );
+  border-radius: 100px;
+  transform: rotate(var(--angle, 220deg));
+  animation: shooting-star-move var(--duration, 1500ms) linear forwards;
+  filter: drop-shadow(0 0 6px rgba(192, 180, 255, 0.8));
+}
+
+.shooting-star::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 0 10px 2px rgba(255, 255, 255, 0.8),
+              0 0 20px 4px rgba(192, 180, 255, 0.6);
+}
+
+@keyframes shooting-star-move {
+  0% {
+    opacity: 0;
+    transform: rotate(var(--angle, 220deg)) translateX(0);
+  }
+  10% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+    transform: rotate(var(--angle, 220deg)) translateX(400px);
+  }
+}

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,0 +1,11 @@
+export function generateUUID(): string {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  // Fallback for older browsers / insecure contexts
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
## Summary

- Add **two-axis globe drag** with vertical tilt, momentum, and auto-return
- Add **Space** keyboard shortcut to pause/resume rotation with toast notification
- Add **shooting stars** background animation
- Make Sentry logo clickable (opens sentry.io in new tab)

## Fixes

- **Mobile performance**: Globe rotation and momentum are now time-based for consistent speed across frame rates
- **Mobile compatibility**: Added UUID fallback for older browsers that don't support `crypto.randomUUID()`

## Details

### Two-Axis Globe Drag
Drag vertically to tilt the globe (theta: -0.6 to 1.0). Includes momentum on release and auto-return to default tilt when idle.

### Pause/Resume Shortcut
Press Space to pause/resume globe rotation. Displays a purple-themed toast with keyboard badge.

### Shooting Stars
Diagonal streaks appear from top and left edges every 8-15 seconds.