### PR TITLE
perf(frontend): optimize animations for mobile devices

### DIFF
--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -18,6 +18,9 @@ const GLOBE_AUTO_ROTATE_SPEED = 0.000087; // radians per millisecond
 const GLOBE_MARKER_SIZE = 0.02;
 const GLOBE_MAP_BRIGHTNESS = 5;
 const GLOBE_BASE_COLOR: [number, number, number] = [0.34, 0.24, 0.56];
+const GLOBE_MAP_SAMPLES_DESKTOP = 12000;
+const GLOBE_MAP_SAMPLES_MOBILE = 6000;
+const MOBILE_WIDTH = 640;
 const POINTER_VELOCITY_DAMPING = 0.92;
 const POINTER_VELOCITY_DAMPING_Y = 0.88;
 const POINTER_VELOCITY_FACTOR = 0.0007;
@@ -146,8 +149,7 @@ function placePulseElement(
   const x = viewport.offsetX + projected.x * viewport.canvasWidth;
   const y = viewport.offsetY + projected.y * viewport.canvasHeight;
   element.style.transform = `translate3d(${x}px, ${y}px, 0)`;
-  element.style.opacity = projected.visible ? "1" : "0";
-  element.style.filter = projected.visible ? "none" : "blur(3px)";
+  element.classList.toggle("event-pulse--hidden", !projected.visible);
 }
 
 export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
@@ -220,15 +222,16 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
     const resizeObserver = new ResizeObserver(onResize);
     resizeObserver.observe(canvas);
 
+    const isMobile = window.innerWidth <= MOBILE_WIDTH;
     const globe = createGlobe(canvas, {
-      devicePixelRatio: Math.min(window.devicePixelRatio, 2),
+      devicePixelRatio: Math.min(window.devicePixelRatio, isMobile ? 1.5 : 2),
       width: viewport.width,
       height: viewport.height,
       phi: 0,
       theta: GLOBE_THETA,
       dark: 1,
       diffuse: 1.15,
-      mapSamples: 12000,
+      mapSamples: isMobile ? GLOBE_MAP_SAMPLES_MOBILE : GLOBE_MAP_SAMPLES_DESKTOP,
       mapBrightness: GLOBE_MAP_BRIGHTNESS,
       baseColor: GLOBE_BASE_COLOR,
       markerColor: [0.94, 0.73, 0.15],
@@ -248,6 +251,12 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
     const ufoImage = ufoEl.querySelector<HTMLImageElement>(".ufo-seer");
 
     const pulseEls = new Map<string, HTMLDivElement>();
+    let cachedCobeMarkers: Array<{
+      location: [number, number];
+      size: number;
+      color: [number, number, number];
+      id: string;
+    }> = [];
 
     let frame = 0;
     let lastFrameAt = performance.now();
@@ -266,6 +275,13 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
 
       if (pulsesDirtyRef.current) {
         syncPulseElements(pulseLayer, pulseEls, markersRef.current);
+        // Rebuild cached cobe markers only when markers change
+        cachedCobeMarkers = markersRef.current.map((marker) => ({
+          location: [marker.lat, marker.lng] as [number, number],
+          size: GLOBE_MARKER_SIZE,
+          color: marker.color,
+          id: marker.id,
+        }));
         pulsesDirtyRef.current = false;
       }
 
@@ -293,12 +309,7 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
         height: viewport.height,
         phi,
         theta,
-        markers: markersRef.current.map((marker) => ({
-          location: [marker.lat, marker.lng] as [number, number],
-          size: GLOBE_MARKER_SIZE,
-          color: marker.color,
-          id: marker.id,
-        })),
+        markers: cachedCobeMarkers,
       });
 
       const aspect = viewport.width / viewport.height;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -132,9 +132,12 @@ body::after {
   align-items: center;
   justify-content: center;
   pointer-events: none;
-  transition: opacity 0.22s linear, filter 0.22s linear;
-  will-change: transform, opacity;
+  transition: opacity 0.22s linear;
   z-index: 2;
+}
+
+.event-pulse--hidden {
+  opacity: 0;
 }
 
 .ufo-marker {
@@ -174,9 +177,7 @@ body::after {
   opacity: 0;
   filter: blur(0.9px);
   box-shadow: 0 0 12px color-mix(in srgb, var(--pulse-color, #f4f2fa) 56%, transparent);
-  animation:
-    pulse-expand 1.85s cubic-bezier(0.22, 0.61, 0.36, 1) infinite,
-    pulse-drift 6.8s ease-in-out infinite alternate;
+  animation: pulse-expand 1.85s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
 }
 
 .event-pulse-dot {
@@ -201,14 +202,7 @@ body::after {
   }
 }
 
-@keyframes pulse-drift {
-  0% {
-    filter: blur(0.9px) hue-rotate(-8deg) saturate(1.02);
-  }
-  100% {
-    filter: blur(0.9px) hue-rotate(12deg) saturate(1.14);
-  }
-}
+
 
 @keyframes star-drift {
   from {
@@ -244,21 +238,6 @@ body::after {
   100% {
     transform: rotate(0deg) scale(1);
   }
-}
-
-@keyframes feed-item-enter {
-  from {
-    opacity: 0;
-    transform: translateY(-6px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
-.live-feed-list li {
-  animation: feed-item-enter 0.24s ease-out;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary

Fixes animation slowdown on mobile devices after repeated interactions.

## Changes

### CSS Optimizations
- Remove expensive `pulse-drift` filter animation (was animating `blur`, `hue-rotate`, `saturate` on 36 elements)
- Remove `will-change` from pulse elements to reduce compositor layer count
- Remove live feed entry animation

### JS Optimizations
- Use CSS class toggle (`.event-pulse--hidden`) instead of inline `filter`/`opacity` styles
- Cache cobe marker objects - only rebuild when markers actually change
- Reduce `mapSamples` from 12000 to 6000 on mobile
- Reduce `devicePixelRatio` cap from 2 to 1.5 on mobile

## Why

Mobile devices have limited GPU memory and compositor layer budgets. The previous implementation was:
1. Running expensive CSS filter animations continuously on up to 36 pulse elements
2. Setting inline `filter` styles every frame via JS (triggers repaints)
3. Creating too many compositor layers with `will-change`
4. Allocating new marker objects every frame (GC pressure)
5. Using desktop-level rendering quality on mobile