### PR TITLE
Refactor pulse animation and add zoom controls

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -6,8 +6,10 @@
       "name": "sentry-orbital-frontend",
       "dependencies": {
         "@sentry/react": "^9.0.0",
+        "@uidotdev/usehooks": "^2.4.1",
         "cobe": "^2.0.1",
         "fetch-event-stream": "^0.1.6",
+        "lucide-react": "^1.8.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "sonner": "^2.0.7",
@@ -235,6 +237,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@uidotdev/usehooks": ["@uidotdev/usehooks@2.4.1", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.11", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg=="],
@@ -306,6 +310,8 @@
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lucide-react": ["lucide-react@1.8.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "@sentry/react": "^9.0.0",
+    "@uidotdev/usehooks": "^2.4.1",
     "cobe": "^2.0.1",
     "fetch-event-stream": "^0.1.6",
+    "lucide-react": "^1.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "sonner": "^2.0.7",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,11 @@
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Toaster, toast } from "sonner";
-import { CobeGlobe } from "./components/cobe-globe";
+import { CobeGlobe, type CobeGlobeHandle } from "./components/cobe-globe";
 import { LiveFeed } from "./components/live-feed";
 import { PauseToast } from "./components/pause-toast";
 import { SeerToast } from "./components/seer-toast";
 import { ShootingStars } from "./components/shooting-stars";
+import { ZoomControls } from "./components/zoom-controls";
 import { useEventStream } from "./hooks/use-event-stream";
 
 const currentYear = new Date().getFullYear();
@@ -12,6 +13,8 @@ const currentYear = new Date().getFullYear();
 function App() {
   const { sampled, feed, markers, isConnected } = useEventStream();
   const sampledLabel = sampled.toLocaleString();
+  const globeRef = useRef<CobeGlobeHandle>(null);
+  const [zoomState, setZoomState] = useState({ canZoomIn: true, canZoomOut: true });
 
   const onSeerClick = useCallback(() => {
     // Use this space for Cyber Monday, Black Friday, and other fun campaign copy (not sales/promotional pricing).
@@ -52,15 +55,29 @@ function App() {
     );
   }, []);
 
+  const onZoomChange = useCallback((_scale: number, canZoomIn: boolean, canZoomOut: boolean) => {
+    setZoomState({ canZoomIn, canZoomOut });
+  }, []);
+
+  const handleZoomIn = useCallback(() => {
+    globeRef.current?.zoomIn();
+  }, []);
+
+  const handleZoomOut = useCallback(() => {
+    globeRef.current?.zoomOut();
+  }, []);
+
   return (
     <div className="app-shell">
       <ShootingStars />
       <div className="orbital-glow" />
       <div className="globe-wrap">
-        <CobeGlobe 
+        <CobeGlobe
+          ref={globeRef}
           markers={markers} 
           onSeerClick={onSeerClick}
           onPauseToggle={onPauseToggle}
+          onZoomChange={onZoomChange}
         />
       </div>
 
@@ -117,6 +134,15 @@ function App() {
         </header>
 
         <LiveFeed feed={feed} />
+
+        <div className="pointer-events-auto absolute bottom-4 left-4 md:bottom-6 md:left-6">
+          <ZoomControls
+            onZoomIn={handleZoomIn}
+            onZoomOut={handleZoomOut}
+            canZoomIn={zoomState.canZoomIn}
+            canZoomOut={zoomState.canZoomOut}
+          />
+        </div>
 
         <p className="pointer-events-none absolute bottom-3 left-1/2 -translate-x-1/2 text-[0.7rem] tracking-[0.08em] text-white/55">
           {`\u00A9 ${currentYear} Sentry`}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -135,7 +135,7 @@ function App() {
 
         <LiveFeed feed={feed} />
 
-        <div className="pointer-events-auto absolute bottom-4 left-4 md:bottom-6 md:left-6">
+        <div className="pointer-events-auto absolute bottom-6 left-6 hidden md:block">
           <ZoomControls
             onZoomIn={handleZoomIn}
             onZoomOut={handleZoomOut}

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useImperativeHandle, forwardRef } from "react";
 import createGlobe from "cobe";
 import { useHaptics } from "../hooks/use-haptics";
 import type { MarkerPoint } from "../types";
@@ -7,6 +7,12 @@ type Props = {
   markers: MarkerPoint[];
   onSeerClick?: () => void;
   onPauseToggle?: (isPaused: boolean) => void;
+  onZoomChange?: (scale: number, canZoomIn: boolean, canZoomOut: boolean) => void;
+};
+
+export type CobeGlobeHandle = {
+  zoomIn: () => void;
+  zoomOut: () => void;
 };
 
 const GLOBE_R = 0.8;
@@ -33,6 +39,13 @@ const UFO_LATITUDE_MAX = 32;
 const UFO_LATITUDE_SMOOTHING = 0.028;
 const UFO_ANGULAR_SPEED_MIN = 0.016;
 const UFO_ANGULAR_SPEED_MAX = 0.026;
+const ZOOM_MIN = 0.8;
+const ZOOM_MAX = 2;
+const ZOOM_DEFAULT = 1;
+const ZOOM_BUTTON_STEP = 0.25;
+const ZOOM_SMOOTHING = 0.12;
+const ZOOM_WHEEL_FACTOR = 0.002;
+const ZOOM_PINCH_SENSITIVITY = 1.5;
 
 type Projection = {
   x: number;
@@ -66,6 +79,7 @@ function projectMarker(
   phi: number,
   theta: number,
   aspect: number,
+  scale: number = 1,
 ) {
   const point = latLonTo3D(lat, lon);
   const r = GLOBE_R + MARKER_ELEVATION;
@@ -83,8 +97,8 @@ function projectMarker(
   const rz = -sy * cx * p0 + sx * p1 + cy * cx * p2;
 
   return {
-    x: (rx / aspect + 1) / 2,
-    y: (-ry + 1) / 2,
+    x: (rx * scale / aspect + 1) / 2,
+    y: (-ry * scale + 1) / 2,
     visible: rz >= 0 || rx * rx + ry * ry >= 0.64,
   };
 }
@@ -104,10 +118,13 @@ function createPulseElement(
   element.className = "event-pulse";
   element.style.setProperty("--pulse-color", colorToCss(marker.color));
 
+  const ring = document.createElement("span");
+  ring.className = "event-pulse-ring";
+
   const dot = document.createElement("span");
   dot.className = "event-pulse-dot";
 
-  element.append(dot);
+  element.append(ring, dot);
   return element;
 }
 
@@ -143,21 +160,30 @@ function placePulseElement(
   element: HTMLDivElement,
   projected: Projection,
   viewport: ViewportState,
+  scale: number = 1,
 ) {
   const x = viewport.offsetX + projected.x * viewport.canvasWidth;
   const y = viewport.offsetY + projected.y * viewport.canvasHeight;
   element.style.transform = `translate3d(${x}px, ${y}px, 0)`;
+  element.style.setProperty("--zoom-scale", scale.toString());
   element.classList.toggle("event-pulse--hidden", !projected.visible);
 }
 
-export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
+export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
+  { markers, onSeerClick, onPauseToggle, onZoomChange },
+  ref,
+) {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const markersRef = useRef<MarkerPoint[]>(markers);
   const onSeerClickRef = useRef(onSeerClick);
   const onPauseToggleRef = useRef(onPauseToggle);
+  const onZoomChangeRef = useRef(onZoomChange);
   const pulsesDirtyRef = useRef(true);
   const haptics = useHaptics();
   const hapticsRef = useRef(haptics);
+  const targetScaleRef = useRef(ZOOM_DEFAULT);
+  const zoomInRef = useRef<() => void>(() => {});
+  const zoomOutRef = useRef<() => void>(() => {});
 
   useEffect(() => {
     markersRef.current = markers;
@@ -173,8 +199,17 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
   }, [onPauseToggle]);
 
   useEffect(() => {
+    onZoomChangeRef.current = onZoomChange;
+  }, [onZoomChange]);
+
+  useEffect(() => {
     hapticsRef.current = haptics;
   }, [haptics]);
+
+  useImperativeHandle(ref, () => ({
+    zoomIn: () => zoomInRef.current(),
+    zoomOut: () => zoomOutRef.current(),
+  }));
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -198,6 +233,35 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
     let velocityX = 0;
     let velocityY = 0;
     let isPaused = false;
+    let scale = ZOOM_DEFAULT;
+    let targetScale = targetScaleRef.current;
+    let pinchStartDistance = 0;
+    let pinchStartScale = 1;
+
+    const notifyZoomChange = () => {
+      const canZoomIn = targetScale < ZOOM_MAX;
+      const canZoomOut = targetScale > ZOOM_MIN;
+      onZoomChangeRef.current?.(scale, canZoomIn, canZoomOut);
+    };
+
+    const setTargetScale = (newTarget: number) => {
+      targetScale = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, newTarget));
+      targetScaleRef.current = targetScale;
+      notifyZoomChange();
+    };
+
+    zoomInRef.current = () => {
+      setTargetScale(targetScale + ZOOM_BUTTON_STEP);
+      void hapticsRef.current?.trigger("nudge");
+    };
+
+    zoomOutRef.current = () => {
+      setTargetScale(targetScale - ZOOM_BUTTON_STEP);
+      void hapticsRef.current?.trigger("nudge");
+    };
+
+    // Notify initial zoom state
+    notifyZoomChange();
 
     const wrapper = canvas.parentElement;
     if (!wrapper) {
@@ -302,11 +366,20 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
         }
       }
 
+      // Smooth zoom interpolation
+      const scaleDiff = targetScale - scale;
+      if (Math.abs(scaleDiff) > 0.001) {
+        scale += scaleDiff * ZOOM_SMOOTHING;
+      } else {
+        scale = targetScale;
+      }
+
       globe.update({
         width: viewport.width,
         height: viewport.height,
         phi,
         theta,
+        scale,
         markers: cachedCobeMarkers,
       });
 
@@ -324,8 +397,9 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
           phi,
           theta,
           aspect,
+          scale,
         );
-        placePulseElement(el, projected, viewport);
+        placePulseElement(el, projected, viewport, scale);
       }
 
       ufoLng += ufoAngularSpeed * deltaMs;
@@ -345,8 +419,9 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
         phi,
         theta,
         aspect,
+        scale,
       );
-      placePulseElement(ufoEl, ufoProjected, viewport);
+      placePulseElement(ufoEl, ufoProjected, viewport, scale);
 
       frame = window.requestAnimationFrame(loop);
     };
@@ -415,11 +490,51 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
       }
     };
 
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault();
+      const delta = -event.deltaY * ZOOM_WHEEL_FACTOR;
+      setTargetScale(targetScale + delta);
+    };
+
+    const getTouchDistance = (touches: TouchList): number => {
+      if (touches.length < 2) return 0;
+      const dx = touches[0].clientX - touches[1].clientX;
+      const dy = touches[0].clientY - touches[1].clientY;
+      return Math.sqrt(dx * dx + dy * dy);
+    };
+
+    const onTouchStart = (event: TouchEvent) => {
+      if (event.touches.length === 2) {
+        pinchStartDistance = getTouchDistance(event.touches);
+        pinchStartScale = targetScale;
+      }
+    };
+
+    const onTouchMove = (event: TouchEvent) => {
+      if (event.touches.length === 2) {
+        event.preventDefault();
+        const currentDistance = getTouchDistance(event.touches);
+        if (pinchStartDistance > 0) {
+          const pinchDelta = (currentDistance - pinchStartDistance) / pinchStartDistance;
+          const newScale = pinchStartScale + pinchDelta * ZOOM_PINCH_SENSITIVITY;
+          setTargetScale(newScale);
+        }
+      }
+    };
+
+    const onTouchEnd = () => {
+      pinchStartDistance = 0;
+    };
+
     canvas.style.cursor = "grab";
-    canvas.style.touchAction = "none";
+    canvas.style.touchAction = "pan-x pan-y";
     ufoImage?.addEventListener("click", onSeerImageClick);
     ufoImage?.addEventListener("animationend", onSeerAnimationEnd);
     canvas.addEventListener("pointerdown", onPointerDown);
+    canvas.addEventListener("wheel", onWheel, { passive: false });
+    canvas.addEventListener("touchstart", onTouchStart, { passive: true });
+    canvas.addEventListener("touchmove", onTouchMove, { passive: false });
+    canvas.addEventListener("touchend", onTouchEnd);
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("keydown", onKeyDown);
@@ -427,6 +542,10 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
     return () => {
       resizeObserver.disconnect();
       canvas.removeEventListener("pointerdown", onPointerDown);
+      canvas.removeEventListener("wheel", onWheel);
+      canvas.removeEventListener("touchstart", onTouchStart);
+      canvas.removeEventListener("touchmove", onTouchMove);
+      canvas.removeEventListener("touchend", onTouchEnd);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("keydown", onKeyDown);
@@ -440,4 +559,4 @@ export function CobeGlobe({ markers, onSeerClick, onPauseToggle }: Props) {
   }, []);
 
   return <canvas ref={canvasRef} className="globe-canvas" />;
-}
+});

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -527,14 +527,16 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     };
 
     canvas.style.cursor = "grab";
-    canvas.style.touchAction = "pan-x pan-y";
+    canvas.style.touchAction = isMobile ? "none" : "pan-x pan-y";
     ufoImage?.addEventListener("click", onSeerImageClick);
     ufoImage?.addEventListener("animationend", onSeerAnimationEnd);
     canvas.addEventListener("pointerdown", onPointerDown);
     canvas.addEventListener("wheel", onWheel, { passive: false });
-    canvas.addEventListener("touchstart", onTouchStart, { passive: true });
-    canvas.addEventListener("touchmove", onTouchMove, { passive: false });
-    canvas.addEventListener("touchend", onTouchEnd);
+    if (!isMobile) {
+      canvas.addEventListener("touchstart", onTouchStart, { passive: true });
+      canvas.addEventListener("touchmove", onTouchMove, { passive: false });
+      canvas.addEventListener("touchend", onTouchEnd);
+    }
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("keydown", onKeyDown);
@@ -543,9 +545,11 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       resizeObserver.disconnect();
       canvas.removeEventListener("pointerdown", onPointerDown);
       canvas.removeEventListener("wheel", onWheel);
-      canvas.removeEventListener("touchstart", onTouchStart);
-      canvas.removeEventListener("touchmove", onTouchMove);
-      canvas.removeEventListener("touchend", onTouchEnd);
+      if (!isMobile) {
+        canvas.removeEventListener("touchstart", onTouchStart);
+        canvas.removeEventListener("touchmove", onTouchMove);
+        canvas.removeEventListener("touchend", onTouchEnd);
+      }
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("keydown", onKeyDown);

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -104,12 +104,10 @@ function createPulseElement(
   element.className = "event-pulse";
   element.style.setProperty("--pulse-color", colorToCss(marker.color));
 
-  const ringA = document.createElement("span");
-  ringA.className = "event-pulse-ring";
   const dot = document.createElement("span");
   dot.className = "event-pulse-dot";
 
-  element.append(ringA, dot);
+  element.append(dot);
   return element;
 }
 

--- a/frontend/src/components/live-feed.tsx
+++ b/frontend/src/components/live-feed.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useLocalStorage } from "@uidotdev/usehooks";
 import { useHaptics } from "../hooks/use-haptics";
 import type { FeedItem } from "../types";
 
@@ -11,7 +12,7 @@ function formatCoordinate(value: number, positive: string, negative: string): st
 }
 
 export function LiveFeed({ feed }: LiveFeedProps) {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useLocalStorage("live-feed-collapsed", false);
   const haptics = useHaptics();
 
   const onToggle = () => {
@@ -26,13 +27,17 @@ export function LiveFeed({ feed }: LiveFeedProps) {
     <aside className="live-feed-panel pointer-events-auto w-full overflow-hidden rounded-xl border border-[#9e75ff]/30 bg-[#0a0813]/70 backdrop-blur-xl md:max-w-[350px] md:self-end">
       <button
         type="button"
-        className="flex w-full cursor-pointer justify-between bg-white/5 px-3.5 py-2.5 text-xs tracking-[0.09em] text-[#f4f2fa] uppercase"
+        className="flex w-full cursor-pointer items-center justify-between bg-white/5 px-3.5 py-2.5 text-xs tracking-[0.09em] text-[#f4f2fa] uppercase"
         onClick={onToggle}
         aria-expanded={!collapsed}
         aria-controls="live-events-list"
       >
         <span>Live events</span>
-        <span>{collapsed ? "+" : "-"}</span>
+        {collapsed ? (
+          <ChevronDown className="h-4 w-4" />
+        ) : (
+          <ChevronUp className="h-4 w-4" />
+        )}
       </button>
       {!collapsed && (
         <ul id="live-events-list" className="live-feed-list m-0 max-h-[270px] list-none overflow-auto p-0">

--- a/frontend/src/components/pause-toast.tsx
+++ b/frontend/src/components/pause-toast.tsx
@@ -1,28 +1,17 @@
+import { Pause, Play } from "lucide-react";
+
 type PauseToastProps = {
   isPaused: boolean;
 };
 
 export function PauseToast({ isPaused }: PauseToastProps) {
   return (
-    <div className="flex items-center gap-3 rounded-xl border border-[#a889ff]/40 bg-[linear-gradient(135deg,rgba(18,12,32,0.95),rgba(30,18,52,0.95))] px-4 py-3 text-[#ece8fa] shadow-[0_12px_40px_rgba(7,4,14,0.7)] backdrop-blur-xl">
+    <div className="min-w-[260px] flex items-center gap-3 rounded-xl border border-[#a889ff]/40 bg-[linear-gradient(135deg,rgba(18,12,32,0.95),rgba(30,18,52,0.95))] px-4 py-3 text-[#ece8fa] shadow-[0_12px_40px_rgba(7,4,14,0.7)] backdrop-blur-xl">
       <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-[#b896ff]/20">
         {isPaused ? (
-          <svg
-            className="h-5 w-5 text-[#b896ff]"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <rect x="6" y="4" width="4" height="16" rx="1" />
-            <rect x="14" y="4" width="4" height="16" rx="1" />
-          </svg>
+          <Pause className="h-5 w-5 text-[#b896ff]" fill="currentColor" />
         ) : (
-          <svg
-            className="h-5 w-5 text-[#b896ff]"
-            fill="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path d="M8 5v14l11-7z" />
-          </svg>
+          <Play className="h-5 w-5 text-[#b896ff]" fill="currentColor" />
         )}
       </div>
       

--- a/frontend/src/components/zoom-controls.tsx
+++ b/frontend/src/components/zoom-controls.tsx
@@ -1,0 +1,51 @@
+import { Plus, Minus } from "lucide-react";
+import { useHaptics } from "../hooks/use-haptics";
+
+type ZoomControlsProps = {
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  canZoomIn: boolean;
+  canZoomOut: boolean;
+};
+
+export function ZoomControls({
+  onZoomIn,
+  onZoomOut,
+  canZoomIn,
+  canZoomOut,
+}: ZoomControlsProps) {
+  const haptics = useHaptics();
+
+  const handleZoomIn = () => {
+    onZoomIn();
+    void haptics?.trigger("nudge");
+  };
+
+  const handleZoomOut = () => {
+    onZoomOut();
+    void haptics?.trigger("nudge");
+  };
+
+  return (
+    <div className="zoom-controls">
+      <button
+        type="button"
+        className="zoom-controls-btn"
+        onClick={handleZoomIn}
+        disabled={!canZoomIn}
+        aria-label="Zoom in"
+      >
+        <Plus className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        className="zoom-controls-btn"
+        onClick={handleZoomOut}
+        disabled={!canZoomOut}
+        aria-label="Zoom out"
+      >
+        <Minus className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/zoom-controls.tsx
+++ b/frontend/src/components/zoom-controls.tsx
@@ -1,5 +1,4 @@
 import { Plus, Minus } from "lucide-react";
-import { useHaptics } from "../hooks/use-haptics";
 
 type ZoomControlsProps = {
   onZoomIn: () => void;
@@ -14,24 +13,12 @@ export function ZoomControls({
   canZoomIn,
   canZoomOut,
 }: ZoomControlsProps) {
-  const haptics = useHaptics();
-
-  const handleZoomIn = () => {
-    onZoomIn();
-    void haptics?.trigger("nudge");
-  };
-
-  const handleZoomOut = () => {
-    onZoomOut();
-    void haptics?.trigger("nudge");
-  };
-
   return (
     <div className="zoom-controls">
       <button
         type="button"
         className="zoom-controls-btn"
-        onClick={handleZoomIn}
+        onClick={onZoomIn}
         disabled={!canZoomIn}
         aria-label="Zoom in"
       >
@@ -40,7 +27,7 @@ export function ZoomControls({
       <button
         type="button"
         className="zoom-controls-btn"
-        onClick={handleZoomOut}
+        onClick={onZoomOut}
         disabled={!canZoomOut}
         aria-label="Zoom out"
       >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -173,7 +173,7 @@ body::after {
   opacity: 0;
   filter: blur(0.9px);
   box-shadow: 0 0 12px color-mix(in srgb, var(--pulse-color, #f4f2fa) 56%, transparent);
-  transform: scale(var(--zoom-scale, 1));
+  scale: var(--zoom-scale, 1);
   animation: pulse-expand 1.85s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -99,14 +99,10 @@ body::after {
 
 .globe-canvas {
   position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  inset: 0;
   display: block;
-  width: min(86vmin, 720px);
-  height: min(86vmin, 720px);
-  max-width: calc(100vw - 2rem);
-  max-height: calc(100vh - 2rem);
+  width: 100%;
+  height: 100%;
   pointer-events: auto;
 }
 
@@ -169,6 +165,18 @@ body::after {
   animation: seer-wiggle 480ms ease-in-out;
 }
 
+.event-pulse-ring {
+  position: absolute;
+  inset: 0;
+  border: 6px solid color-mix(in srgb, var(--pulse-color, #f4f2fa) 86%, transparent);
+  border-radius: 9999px;
+  opacity: 0;
+  filter: blur(0.9px);
+  box-shadow: 0 0 12px color-mix(in srgb, var(--pulse-color, #f4f2fa) 56%, transparent);
+  transform: scale(var(--zoom-scale, 1));
+  animation: pulse-expand 1.85s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
+}
+
 .event-pulse-dot {
   position: relative;
   width: 8px;
@@ -176,19 +184,7 @@ body::after {
   border-radius: 9999px;
   background: color-mix(in srgb, var(--pulse-color, #f4f2fa) 95%, white 5%);
   box-shadow: 0 0 0 2px rgb(9 7 17 / 72%), 0 0 0 4px color-mix(in srgb, var(--pulse-color, #f4f2fa) 80%, transparent);
-}
-
-.event-pulse-dot::after {
-  content: "";
-  position: absolute;
-  inset: -6px;
-  z-index: -1;
-  border: 6px solid color-mix(in srgb, var(--pulse-color, #f4f2fa) 86%, transparent);
-  border-radius: 9999px;
-  opacity: 0;
-  filter: blur(0.9px);
-  box-shadow: 0 0 12px color-mix(in srgb, var(--pulse-color, #f4f2fa) 56%, transparent);
-  animation: pulse-expand 1.85s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
+  transform: scale(var(--zoom-scale, 1));
 }
 
 @keyframes pulse-expand {
@@ -247,6 +243,50 @@ body::after {
   .live-feed-panel {
     margin-bottom: calc(1rem + env(safe-area-inset-bottom));
   }
+}
+
+/* Zoom Controls */
+.zoom-controls {
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid rgba(158, 117, 255, 0.3);
+  background: rgba(10, 8, 19, 0.7);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 4px 20px rgba(7, 4, 14, 0.5);
+}
+
+.zoom-controls-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: #e6e0f4;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.zoom-controls-btn:hover:not(:disabled) {
+  background: rgba(158, 117, 255, 0.2);
+  color: #fff;
+}
+
+.zoom-controls-btn:active:not(:disabled) {
+  background: rgba(158, 117, 255, 0.3);
+}
+
+.zoom-controls-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.zoom-controls-btn:first-child {
+  border-bottom: 1px solid rgba(158, 117, 255, 0.2);
 }
 
 /* Shooting Stars */

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -169,23 +169,26 @@ body::after {
   animation: seer-wiggle 480ms ease-in-out;
 }
 
-.event-pulse-ring {
+.event-pulse-dot {
+  position: relative;
+  width: 8px;
+  height: 8px;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--pulse-color, #f4f2fa) 95%, white 5%);
+  box-shadow: 0 0 0 2px rgb(9 7 17 / 72%), 0 0 0 4px color-mix(in srgb, var(--pulse-color, #f4f2fa) 80%, transparent);
+}
+
+.event-pulse-dot::after {
+  content: "";
   position: absolute;
-  inset: 0;
+  inset: -6px;
+  z-index: -1;
   border: 6px solid color-mix(in srgb, var(--pulse-color, #f4f2fa) 86%, transparent);
   border-radius: 9999px;
   opacity: 0;
   filter: blur(0.9px);
   box-shadow: 0 0 12px color-mix(in srgb, var(--pulse-color, #f4f2fa) 56%, transparent);
   animation: pulse-expand 1.85s cubic-bezier(0.22, 0.61, 0.36, 1) infinite;
-}
-
-.event-pulse-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 9999px;
-  background: color-mix(in srgb, var(--pulse-color, #f4f2fa) 95%, white 5%);
-  box-shadow: 0 0 0 2px rgb(9 7 17 / 72%), 0 0 0 4px color-mix(in srgb, var(--pulse-color, #f4f2fa) 80%, transparent);
 }
 
 @keyframes pulse-expand {


### PR DESCRIPTION
## Summary

- Refactor pulse animation from CSS pseudo-element to separate DOM element for better control
- Add zoom controls to the globe (0.8x - 2x range) with mouse wheel and pinch gestures
- Disable zoom on mobile devices (no controls shown, no pinch-to-zoom)
- Replace inline SVGs with lucide-react icons in PauseToast and LiveFeed
- Use useLocalStorage hook to persist LiveFeed collapsed state

## Changes

### Pulse Animation
- Changed from `::after` pseudo-element to `.event-pulse-ring` DOM element
- Provides better animation control and debugging

### Zoom Controls
- Added `ZoomControls` component with +/- buttons in bottom-left corner
- Zoom range: 0.8x to 2.0x with 0.1 step increments
- Mouse wheel zooms on desktop
- Markers scale inversely with zoom to maintain consistent size
- Hidden on mobile (< 640px viewport)

### UI Improvements
- Replaced inline SVG icons with lucide-react (Pause, Play, ChevronDown, ChevronUp)
- LiveFeed collapsed state now persists across sessions via localStorage