### PR TITLE
fix(frontend): mobile globe pinch-zoom and 50% smaller default size

### DIFF
--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -440,6 +440,11 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
 
     frame = window.requestAnimationFrame(loop);
 
+    const clearDragState = () => {
+      pointerDown = false;
+      canvas.style.cursor = "grab";
+    };
+
     const onPointerDown = (event: PointerEvent) => {
       activePointers.add(event.pointerId);
       if (isPinching) {
@@ -451,15 +456,16 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       canvas.style.cursor = "grabbing";
     };
 
-    const onPointerUp = (event: PointerEvent) => {
+    // pointercancel often fires instead of pointerup (scroll, OS gesture, etc.).
+    // Drop the ID either way so activePointers cannot stick and block drag reset.
+    const onPointerUpOrCancel = (event: PointerEvent) => {
       activePointers.delete(event.pointerId);
       // Keep drag state if another pointer is still down (e.g. post-pinch).
       // onTouchEnd re-arms pointerDown from the remaining touch when needed.
       if (activePointers.size > 0) {
         return;
       }
-      pointerDown = false;
-      canvas.style.cursor = "grab";
+      clearDragState();
     };
 
     const onPointerMove = (event: PointerEvent) => {
@@ -560,7 +566,7 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       // Pinch clears pointerDown; if one finger remains, re-arm drag from that
       // contact so the user can rotate without lifting and retouching.
       // touchend runs after pointerup for the lifted finger on major browsers,
-      // so this restores state that onPointerUp just cleared.
+      // so this restores state that onPointerUpOrCancel just cleared.
       if (event.touches.length === 1) {
         pointerDown = true;
         pointerX = event.touches[0].clientX;
@@ -569,8 +575,18 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
         return;
       }
 
-      pointerDown = false;
-      canvas.style.cursor = "grab";
+      clearDragState();
+    };
+
+    const onTouchCancel = () => {
+      // System interruption: fully reset. Do not re-arm drag from residual
+      // touches — those coordinates go stale and cause a jump on next move.
+      activePointers.clear();
+      isPinching = false;
+      pinchStartDistance = 0;
+      velocityX = 0;
+      velocityY = 0;
+      clearDragState();
     };
 
     canvas.style.cursor = "grab";
@@ -583,8 +599,9 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     canvas.addEventListener("touchstart", onTouchStart, { passive: true });
     canvas.addEventListener("touchmove", onTouchMove, { passive: false });
     canvas.addEventListener("touchend", onTouchEnd);
-    canvas.addEventListener("touchcancel", onTouchEnd);
-    window.addEventListener("pointerup", onPointerUp);
+    canvas.addEventListener("touchcancel", onTouchCancel);
+    window.addEventListener("pointerup", onPointerUpOrCancel);
+    window.addEventListener("pointercancel", onPointerUpOrCancel);
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("keydown", onKeyDown);
 
@@ -595,8 +612,9 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       canvas.removeEventListener("touchstart", onTouchStart);
       canvas.removeEventListener("touchmove", onTouchMove);
       canvas.removeEventListener("touchend", onTouchEnd);
-      canvas.removeEventListener("touchcancel", onTouchEnd);
-      window.removeEventListener("pointerup", onPointerUp);
+      canvas.removeEventListener("touchcancel", onTouchCancel);
+      window.removeEventListener("pointerup", onPointerUpOrCancel);
+      window.removeEventListener("pointercancel", onPointerUpOrCancel);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("keydown", onKeyDown);
       ufoImage?.removeEventListener("click", onSeerImageClick);

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -249,6 +249,7 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     let pinchStartDistance = 0;
     let pinchStartScale = defaultZoom;
     let isPinching = false;
+    const activePointers = new Set<number>();
 
     const notifyZoomChange = () => {
       const canZoomIn = targetScale < ZOOM_MAX;
@@ -440,6 +441,7 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     frame = window.requestAnimationFrame(loop);
 
     const onPointerDown = (event: PointerEvent) => {
+      activePointers.add(event.pointerId);
       if (isPinching) {
         return;
       }
@@ -449,7 +451,13 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       canvas.style.cursor = "grabbing";
     };
 
-    const onPointerUp = () => {
+    const onPointerUp = (event: PointerEvent) => {
+      activePointers.delete(event.pointerId);
+      // Keep drag state if another pointer is still down (e.g. post-pinch).
+      // onTouchEnd re-arms pointerDown from the remaining touch when needed.
+      if (activePointers.size > 0) {
+        return;
+      }
       pointerDown = false;
       canvas.style.cursor = "grab";
     };
@@ -542,10 +550,27 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     };
 
     const onTouchEnd = (event: TouchEvent) => {
-      if (event.touches.length < 2) {
-        isPinching = false;
-        pinchStartDistance = 0;
+      if (event.touches.length >= 2) {
+        return;
       }
+
+      isPinching = false;
+      pinchStartDistance = 0;
+
+      // Pinch clears pointerDown; if one finger remains, re-arm drag from that
+      // contact so the user can rotate without lifting and retouching.
+      // touchend runs after pointerup for the lifted finger on major browsers,
+      // so this restores state that onPointerUp just cleared.
+      if (event.touches.length === 1) {
+        pointerDown = true;
+        pointerX = event.touches[0].clientX;
+        pointerY = event.touches[0].clientY;
+        canvas.style.cursor = "grabbing";
+        return;
+      }
+
+      pointerDown = false;
+      canvas.style.cursor = "grab";
     };
 
     canvas.style.cursor = "grab";

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -39,13 +39,20 @@ const UFO_LATITUDE_MAX = 32;
 const UFO_LATITUDE_SMOOTHING = 0.028;
 const UFO_ANGULAR_SPEED_MIN = 0.016;
 const UFO_ANGULAR_SPEED_MAX = 0.026;
-const ZOOM_MIN = 0.8;
+const ZOOM_MIN = 0.4;
 const ZOOM_MAX = 2;
-const ZOOM_DEFAULT = 1;
+const ZOOM_DEFAULT_DESKTOP = 1;
+const ZOOM_DEFAULT_MOBILE = 0.5; // 50% smaller than desktop for portrait viewports
 const ZOOM_BUTTON_STEP = 0.25;
 const ZOOM_SMOOTHING = 0.12;
 const ZOOM_WHEEL_FACTOR = 0.002;
 const ZOOM_PINCH_SENSITIVITY = 1.5;
+
+function getDefaultZoom(): number {
+  return window.innerWidth <= MOBILE_WIDTH
+    ? ZOOM_DEFAULT_MOBILE
+    : ZOOM_DEFAULT_DESKTOP;
+}
 
 type Projection = {
   x: number;
@@ -181,7 +188,7 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
   const pulsesDirtyRef = useRef(true);
   const haptics = useHaptics();
   const hapticsRef = useRef(haptics);
-  const targetScaleRef = useRef(ZOOM_DEFAULT);
+  const targetScaleRef = useRef(getDefaultZoom());
   const zoomInRef = useRef<() => void>(() => {});
   const zoomOutRef = useRef<() => void>(() => {});
 
@@ -217,6 +224,10 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       return;
     }
 
+    const isMobile = window.innerWidth <= MOBILE_WIDTH;
+    const defaultZoom = isMobile ? ZOOM_DEFAULT_MOBILE : ZOOM_DEFAULT_DESKTOP;
+    targetScaleRef.current = defaultZoom;
+
     let phi = 0;
     let theta = GLOBE_THETA;
     const viewport: ViewportState = {
@@ -233,10 +244,11 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     let velocityX = 0;
     let velocityY = 0;
     let isPaused = false;
-    let scale = ZOOM_DEFAULT;
-    let targetScale = targetScaleRef.current;
+    let scale = defaultZoom;
+    let targetScale = defaultZoom;
     let pinchStartDistance = 0;
-    let pinchStartScale = 1;
+    let pinchStartScale = defaultZoom;
+    let isPinching = false;
 
     const notifyZoomChange = () => {
       const canZoomIn = targetScale < ZOOM_MAX;
@@ -284,7 +296,6 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     const resizeObserver = new ResizeObserver(onResize);
     resizeObserver.observe(canvas);
 
-    const isMobile = window.innerWidth <= MOBILE_WIDTH;
     const globe = createGlobe(canvas, {
       devicePixelRatio: Math.min(window.devicePixelRatio, isMobile ? 1.5 : 2),
       width: viewport.width,
@@ -299,7 +310,7 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       markerColor: [0.94, 0.73, 0.15],
       glowColor: [0.65, 0.47, 1],
       offset: [0, 0],
-      scale: 1,
+      scale: defaultZoom,
     });
 
     const pulseLayer = document.createElement("div");
@@ -429,6 +440,9 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     frame = window.requestAnimationFrame(loop);
 
     const onPointerDown = (event: PointerEvent) => {
+      if (isPinching) {
+        return;
+      }
       pointerDown = true;
       pointerX = event.clientX;
       pointerY = event.clientY;
@@ -441,7 +455,7 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
     };
 
     const onPointerMove = (event: PointerEvent) => {
-      if (!pointerDown) {
+      if (!pointerDown || isPinching) {
         return;
       }
 
@@ -505,8 +519,13 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
 
     const onTouchStart = (event: TouchEvent) => {
       if (event.touches.length === 2) {
+        isPinching = true;
+        pointerDown = false;
+        velocityX = 0;
+        velocityY = 0;
         pinchStartDistance = getTouchDistance(event.touches);
         pinchStartScale = targetScale;
+        canvas.style.cursor = "grab";
       }
     };
 
@@ -522,21 +541,24 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       }
     };
 
-    const onTouchEnd = () => {
-      pinchStartDistance = 0;
+    const onTouchEnd = (event: TouchEvent) => {
+      if (event.touches.length < 2) {
+        isPinching = false;
+        pinchStartDistance = 0;
+      }
     };
 
     canvas.style.cursor = "grab";
-    canvas.style.touchAction = isMobile ? "none" : "pan-x pan-y";
+    // Prevent browser pan/zoom so custom drag + pinch-zoom own the gestures.
+    canvas.style.touchAction = "none";
     ufoImage?.addEventListener("click", onSeerImageClick);
     ufoImage?.addEventListener("animationend", onSeerAnimationEnd);
     canvas.addEventListener("pointerdown", onPointerDown);
     canvas.addEventListener("wheel", onWheel, { passive: false });
-    if (!isMobile) {
-      canvas.addEventListener("touchstart", onTouchStart, { passive: true });
-      canvas.addEventListener("touchmove", onTouchMove, { passive: false });
-      canvas.addEventListener("touchend", onTouchEnd);
-    }
+    canvas.addEventListener("touchstart", onTouchStart, { passive: true });
+    canvas.addEventListener("touchmove", onTouchMove, { passive: false });
+    canvas.addEventListener("touchend", onTouchEnd);
+    canvas.addEventListener("touchcancel", onTouchEnd);
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("keydown", onKeyDown);
@@ -545,11 +567,10 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
       resizeObserver.disconnect();
       canvas.removeEventListener("pointerdown", onPointerDown);
       canvas.removeEventListener("wheel", onWheel);
-      if (!isMobile) {
-        canvas.removeEventListener("touchstart", onTouchStart);
-        canvas.removeEventListener("touchmove", onTouchMove);
-        canvas.removeEventListener("touchend", onTouchEnd);
-      }
+      canvas.removeEventListener("touchstart", onTouchStart);
+      canvas.removeEventListener("touchmove", onTouchMove);
+      canvas.removeEventListener("touchend", onTouchEnd);
+      canvas.removeEventListener("touchcancel", onTouchEnd);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("keydown", onKeyDown);

--- a/frontend/src/components/cobe-globe.tsx
+++ b/frontend/src/components/cobe-globe.tsx
@@ -560,14 +560,13 @@ export const CobeGlobe = forwardRef<CobeGlobeHandle, Props>(function CobeGlobe(
         return;
       }
 
+      const wasPinching = isPinching;
       isPinching = false;
       pinchStartDistance = 0;
 
-      // Pinch clears pointerDown; if one finger remains, re-arm drag from that
-      // contact so the user can rotate without lifting and retouching.
-      // touchend runs after pointerup for the lifted finger on major browsers,
-      // so this restores state that onPointerUpOrCancel just cleared.
-      if (event.touches.length === 1) {
+      // Only re-arm after a real pinch→one-finger transition. Avoids re-arming
+      // from stale touches if touchend follows touchcancel (isPinching already false).
+      if (wasPinching && event.touches.length === 1) {
         pointerDown = true;
         pointerX = event.touches[0].clientX;
         pointerY = event.touches[0].clientY;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Mobile users couldn’t pinch-zoom the globe because pinch handlers were only registered on desktop while `touch-action: none` blocked browser zoom. The globe also filled the portrait viewport and looked cropped.

## Changes
- Default globe scale to **0.5 on mobile** (50% of the previous desktop default), still centered via cobe `offset: [0, 0]`
- Lower zoom floor to `0.4` so the new mobile default is in range
- Enable pinch-zoom on mobile and stop single-finger drag while pinching
- Keep `touch-action: none` so custom drag/pinch own the gestures
- After a pinch ends with one finger still down, re-arm drag from that contact so rotation works without lifting/retouching
- Only re-arm drag when leaving an active pinch (`wasPinching`), so `touchend` after `touchcancel` cannot restore stale drag state
- Handle `pointercancel` so `activePointers` cannot stick without a matching `pointerup`
- Treat `touchcancel` as a full gesture reset (do not re-arm drag from stale residual touches)

## Test plan
- [ ] Open on a phone (or Chrome device mode ≤640px width)
- [ ] Confirm the globe fits in the center at roughly half the previous size
- [ ] Pinch in/out to zoom the globe
- [ ] Single-finger drag still rotates the globe
- [ ] After pinching, keep one finger down and drag — globe should rotate without lifting first
- [ ] Interrupt a touch (e.g. open notification shade / switch apps) — globe should not stay stuck dragging or jump on next touch
- [ ] Desktop zoom buttons / wheel zoom still work as before

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f75f8-f855-7ae7-a950-4b0aa8337f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f75f8-f855-7ae7-a950-4b0aa8337f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

