### PR TITLE
fix(orbital): stop fixed 5% sampling from emptying the globe

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,8 @@ jobs:
           # /healthz must return 200 with body "ok"
           HEALTH=$(curl -sf http://localhost:7000/healthz)
           [ "$HEALTH" = "ok" ] || (echo "healthz returned: $HEALTH" && exit 1)
+          # /stats must return ingest counters JSON
+          curl -sf http://localhost:7000/stats | grep -q 'udp_received' || (echo "stats missing udp_received" && exit 1)
           # / must return 200 and contain the frontend
           curl -sf http://localhost:7000/ | grep -q 'Sentry Live' || (echo "index page missing expected content" && exit 1)
           docker stop orbital-smoke

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Orbital is a geographical visualization of Sentry data — a real-time 3D globe 
 
 ## Architecture
 
-- **Go backend** (`main.go`): Receives UDP events, samples them at 5%, and fans out via SSE to connected browsers
+- **Go backend** (`main.go`): Receives UDP events, rate-limits them (~50/s max), and fans out via SSE to connected browsers
 - **React frontend** (`frontend/`): Vite + React + TypeScript app using [cobe](https://github.com/shuding/cobe) for the WebGL globe
 
 ## Development
@@ -61,8 +61,11 @@ docker run --rm -p 7000:7000 -p 5556:5556/udp -e HOST=0.0.0.0 sentry-orbital
 | `-host` | `127.0.0.1` | Listen address |
 | `-http-port` | `7000` | HTTP port |
 | `-udp-port` | `5556` | UDP port for event ingest |
-| `-sample-rate` | `0.05` | Fraction of events to forward (0.0–1.0) |
+| `-sample-rate` | `1.0` | Fraction of UDP events eligible to forward (0.0–1.0) |
+| `-max-forward-rate` | `50` | Max events/sec forwarded to SSE clients (`0` = unlimited) |
 | `-test` | `false` | Enable test event generator |
+
+`/stats` exposes cumulative UDP `received` / `forwarded` / `dropped` counters for diagnosing ingest outages.
 
 ## UDP Event Format
 

--- a/frontend/src/hooks/use-event-stream.ts
+++ b/frontend/src/hooks/use-event-stream.ts
@@ -29,6 +29,9 @@ const WATCHDOG_MS = 5000;
 const RETRY_MS = 3000;
 const FEED_RATE_MS = 320;
 const STATS_INTERVAL_MS = 1000;
+// Drop only clearly-stale buffered bursts. Source clocks and proxy buffering
+// can push live events past 10s; 60s still rejects tab-resume floods.
+const STALE_EVENT_MS = 60_000;
 
 function toMarker(event: OrbitalEvent): MarkerPoint {
   const markerId = generateUUID();
@@ -153,16 +156,29 @@ export function useEventStream() {
     let sourceAbort: AbortController | null = null;
     let lastMarkerAt = Date.now();
     let lastFeedAt = Date.now();
-    let lastStatsAt = Date.now();
     let sampledDelta = 0;
     let watchdogTimer: ReturnType<typeof setTimeout> | null = null;
+    let statsTimer: ReturnType<typeof setInterval> | null = null;
     let closed = false;
     let reconnectPending = false;
+
+    const flushSampledDelta = () => {
+      if (sampledDelta === 0) {
+        return;
+      }
+      const delta = sampledDelta;
+      sampledDelta = 0;
+      setSampled((current) => current + delta);
+    };
 
     const clearTimers = () => {
       if (watchdogTimer !== null) {
         clearTimeout(watchdogTimer);
         watchdogTimer = null;
+      }
+      if (statsTimer !== null) {
+        clearInterval(statsTimer);
+        statsTimer = null;
       }
     };
 
@@ -209,7 +225,9 @@ export function useEventStream() {
       const now = Date.now();
       const fresh: OrbitalEvent[] = [];
       for (const event of events) {
-        if (now - event.ts <= 10_000) {
+        // Only drop events that are genuinely old (past direction). Future
+        // timestamps are kept — source clocks may run ahead of the client.
+        if (now - event.ts <= STALE_EVENT_MS) {
           fresh.push(event);
         }
       }
@@ -222,14 +240,8 @@ export function useEventStream() {
         fresh.sort((a, b) => a.ts - b.ts);
       }
 
-      // Track delta since last update, flush to state at fixed intervals
+      // Accumulate; a fixed interval flushes to React state (see statsTimer).
       sampledDelta += fresh.length;
-      if (now - lastStatsAt >= STATS_INTERVAL_MS) {
-        lastStatsAt = now;
-        const delta = sampledDelta;
-        sampledDelta = 0;
-        setSampled((current) => current + delta);
-      }
 
       const allowedAdds = Math.min(
         fresh.length,
@@ -306,10 +318,12 @@ export function useEventStream() {
       }
     };
 
+    statsTimer = setInterval(flushSampledDelta, STATS_INTERVAL_MS);
     connect();
 
     return () => {
       closed = true;
+      flushSampledDelta();
       clearTimers();
       sourceAbort?.abort();
     };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     proxy: {
       "/stream": "http://localhost:7000",
       "/healthz": "http://localhost:7000",
+      "/stats": "http://localhost:7000",
     },
   },
 });

--- a/main.go
+++ b/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	sentry "github.com/getsentry/sentry-go"
@@ -15,16 +17,35 @@ import (
 )
 
 var (
-	flagHost       = flag.String("host", "127.0.0.1", "listen addr")
-	flagHttpPort   = flag.Int("http-port", 7000, "http port")
-	flagUdpPort    = flag.Int("udp-port", 5556, "udp port")
-	flagTest       = flag.Bool("test", false, "send test events")
-	flagSampleRate = flag.Float64("sample-rate", 0.05, "fraction of UDP events to forward to SSE clients (0.0–1.0)")
+	flagHost           = flag.String("host", "127.0.0.1", "listen addr")
+	flagHttpPort       = flag.Int("http-port", 7000, "http port")
+	flagUdpPort        = flag.Int("udp-port", 5556, "udp port")
+	flagTest           = flag.Bool("test", false, "send test events")
+	flagSampleRate     = flag.Float64("sample-rate", 1.0, "fraction of UDP events eligible to forward (0.0–1.0); applied before max-forward-rate")
+	flagMaxForwardRate = flag.Float64("max-forward-rate", 50, "max events/sec to forward to SSE clients (0 = unlimited)")
 )
+
+// ingestStats tracks UDP receive/forward counters for /stats.
+var ingestStats struct {
+	received  atomic.Uint64
+	forwarded atomic.Uint64
+	dropped   atomic.Uint64
+}
 
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("ok"))
+}
+
+func handleStats(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"udp_received":  ingestStats.received.Load(),
+		"udp_forwarded": ingestStats.forwarded.Load(),
+		"udp_dropped":   ingestStats.dropped.Load(),
+		"sample_rate":   *flagSampleRate,
+		"max_forward_rate": *flagMaxForwardRate,
+	})
 }
 
 func runTest(port int) {
@@ -191,8 +212,8 @@ func init() {
 
 func main() {
 	if err := sentry.Init(sentry.ClientOptions{
-		Dsn:              "https://da9a4372645d168eff259433fb2403c9@o1.ingest.us.sentry.io/4510957955514368",
-		EnableTracing:    true,
+		Dsn:           "https://da9a4372645d168eff259433fb2403c9@o1.ingest.us.sentry.io/4510957955514368",
+		EnableTracing: true,
 		// 100% trace sampling — intentional for this low-traffic demo app.
 		// Reduce for high-traffic deployments.
 		TracesSampleRate: 1.0,
@@ -216,6 +237,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", handleHealth)
+	mux.HandleFunc("/stats", handleStats)
 	mux.Handle("/stream", es)
 	// Serve the Vite-built frontend from static/
 	mux.Handle("/", http.FileServer(http.Dir("static")))
@@ -231,6 +253,7 @@ func main() {
 	}
 	defer conn.Close()
 	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	// Heartbeat: send a ping every 3s so the client watchdog doesn't
 	// fire during legitimate low-traffic periods.
 	go func() {
@@ -241,8 +264,34 @@ func main() {
 		}
 	}()
 
+	// Periodic ingest rate logging — makes empty-globe outages obvious.
+	go func() {
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+		var prevRecv, prevFwd uint64
+		for range ticker.C {
+			recv := ingestStats.received.Load()
+			fwd := ingestStats.forwarded.Load()
+			log.Printf(
+				"ingest: received=%.1f/s forwarded=%.1f/s (total recv=%d fwd=%d drop=%d)",
+				float64(recv-prevRecv)/30,
+				float64(fwd-prevFwd)/30,
+				recv,
+				fwd,
+				ingestStats.dropped.Load(),
+			)
+			prevRecv, prevFwd = recv, fwd
+		}
+	}()
+
 	go func() {
 		b := make([]byte, 256)
+		var lastForward time.Time
+		var minGap time.Duration
+		if *flagMaxForwardRate > 0 {
+			minGap = time.Duration(float64(time.Second) / *flagMaxForwardRate)
+		}
+
 		for {
 			n, _, err := conn.ReadFromUDP(b)
 			if err != nil {
@@ -251,12 +300,25 @@ func main() {
 				log.Fatal(err)
 				return
 			}
-			if rng.Float64() >= *flagSampleRate {
+			ingestStats.received.Add(1)
+
+			if *flagSampleRate < 1.0 && rng.Float64() >= *flagSampleRate {
+				ingestStats.dropped.Add(1)
 				continue
 			}
+			if minGap > 0 {
+				now := time.Now()
+				if !lastForward.IsZero() && now.Sub(lastForward) < minGap {
+					ingestStats.dropped.Add(1)
+					continue
+				}
+				lastForward = now
+			}
+
 			d := make([]byte, n)
 			copy(d, b)
 			es.SendEventMessage(d)
+			ingestStats.forwarded.Add(1)
 		}
 	}()
 

--- a/main.go
+++ b/main.go
@@ -286,10 +286,36 @@ func main() {
 
 	go func() {
 		b := make([]byte, 256)
-		var lastForward time.Time
-		var minGap time.Duration
-		if *flagMaxForwardRate > 0 {
-			minGap = time.Duration(float64(time.Second) / *flagMaxForwardRate)
+		// Token bucket so UDP bursts still achieve max-forward-rate over time.
+		// A min-gap gate would drop almost an entire kernel backlog because
+		// time.Now barely advances between tight ReadFromUDP iterations.
+		var (
+			forwardRate  = *flagMaxForwardRate
+			forwardBurst float64
+			tokens       float64
+			lastRefill   time.Time
+		)
+		if forwardRate > 0 {
+			forwardBurst = forwardRate // allow up to 1s of burst
+			tokens = forwardBurst
+			lastRefill = time.Now()
+		}
+
+		allowForward := func() bool {
+			if forwardRate <= 0 {
+				return true
+			}
+			now := time.Now()
+			tokens += now.Sub(lastRefill).Seconds() * forwardRate
+			lastRefill = now
+			if tokens > forwardBurst {
+				tokens = forwardBurst
+			}
+			if tokens < 1 {
+				return false
+			}
+			tokens--
+			return true
 		}
 
 		for {
@@ -306,13 +332,9 @@ func main() {
 				ingestStats.dropped.Add(1)
 				continue
 			}
-			if minGap > 0 {
-				now := time.Now()
-				if !lastForward.IsZero() && now.Sub(lastForward) < minGap {
-					ingestStats.dropped.Add(1)
-					continue
-				}
-				lastForward = now
+			if !allowForward() {
+				ingestStats.dropped.Add(1)
+				continue
 			}
 
 			d := make([]byte, n)

--- a/main.go
+++ b/main.go
@@ -296,7 +296,13 @@ func main() {
 			lastRefill   time.Time
 		)
 		if forwardRate > 0 {
-			forwardBurst = forwardRate // allow up to 1s of burst
+			// Burst is 1s of rate, but never below 1 token — otherwise any
+			// 0 < max-forward-rate < 1 permanently caps the bucket below the
+			// cost of a single forward and drops every event.
+			forwardBurst = forwardRate
+			if forwardBurst < 1 {
+				forwardBurst = 1
+			}
 			tokens = forwardBurst
 			lastRefill = time.Now()
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Findings

Probed production `https://live.sentry.io/stream` for ~90s:

| Signal | Observed |
|--------|----------|
| Heartbeats | Healthy (~every 3s) |
| Forwarded events | **~0.08/s** (7 events / 90s) |
| Platforms | **Only `php`** |
| Locations | Only 2 repeating coords (Cayman/Helsinki) |

The Go server is up, but UDP ingest volume has collapsed. The previous default `-sample-rate=0.05` was sized for ~1000s UDP events/sec → ~50 SSE events/sec. At today’s ~1–2 UDP events/sec, that same 5% rate forwards almost nothing, so the globe looks empty.

This is **not** a frontend SSE/connect bug. Client freshness filtering was a secondary concern under sparse/bursty delivery; the primary issue is server-side over-sampling of an already-thin feed.

**Follow-up needed outside this repo:** the getsentry UDP publisher that feeds orbital appears degraded (php-only, 2 geos). That shim is vendored into `getsentry` per the repo description — worth checking there / in ops.

## Fix

- Default `-sample-rate` **1.0** (forward all eligible UDP events)
- Add `-max-forward-rate` **50** (cap SSE fanout if ingest recovers to high volume)
- Rate limit via a **token bucket** (burst = `max(rate, 1)`), not a min-gap gate — so UDP backlogs still achieve the configured rate, and fractional rates like `0.5` can accumulate a token instead of dropping everything
- Add `/stats` + 30s ingest logs (`received/forwarded/dropped` rates)
- Client: widen stale window to 60s; flush sampled counter on a timer + reconnect cleanup so sparse traffic still increments the UI

## Test plan

- [x] Local: `go build` + `-test -max-forward-rate=50` → `/stats` shows ~50/s forward under bursty test generator; stream carries diverse platforms
- [x] Token bucket forwards a full instantaneous burst up to burst capacity (min-gap would forward 1)
- [x] Fractional rates keep burst ≥ 1 so events are not permanently dropped
- [ ] CI smoke test passes (`/healthz`, `/stats`, index)
- [ ] After deploy: `curl -s https://live.sentry.io/stats` shows non-trivial `udp_received`; globe markers resume
- [ ] Confirm upstream publisher diversity separately (not fixed here)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f75f7-121a-762f-9671-072ed822f87e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f75f7-121a-762f-9671-072ed822f87e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

