### PR TITLE
feat: add /stats endpoint for UDP ingest diagnostics

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"time"
 
 	sentry "github.com/getsentry/sentry-go"
@@ -25,6 +27,34 @@ var (
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("ok"))
+}
+
+// Diagnostic counters for /stats, to understand where events are being lost
+// (e.g. whether UDP packets from getsentry are reaching this server at all).
+var (
+	statUDPReceived  atomic.Uint64 // packets read off the UDP socket (pre-sample)
+	statForwarded    atomic.Uint64 // packets forwarded to SSE clients (post-sample)
+	statLastRecvUnix atomic.Int64  // unix seconds of the last UDP packet received
+	statLastPayload  atomic.Value  // string: last raw payload seen
+)
+
+func handleStats(w http.ResponseWriter, r *http.Request) {
+	last, _ := statLastPayload.Load().(string)
+	lastRecv := statLastRecvUnix.Load()
+	secondsSinceRecv := int64(-1)
+	if lastRecv > 0 {
+		secondsSinceRecv = time.Now().Unix() - lastRecv
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]any{
+		"udp_received":       statUDPReceived.Load(),
+		"forwarded":          statForwarded.Load(),
+		"sample_rate":        *flagSampleRate,
+		"last_recv_unix":     lastRecv,
+		"seconds_since_recv": secondsSinceRecv,
+		"last_payload":       last,
+	})
 }
 
 func runTest(port int) {
@@ -216,6 +246,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", handleHealth)
+	mux.HandleFunc("/stats", handleStats)
 	mux.Handle("/stream", es)
 	// Serve the Vite-built frontend from static/
 	mux.Handle("/", http.FileServer(http.Dir("static")))
@@ -251,9 +282,13 @@ func main() {
 				log.Fatal(err)
 				return
 			}
+			statUDPReceived.Add(1)
+			statLastRecvUnix.Store(time.Now().Unix())
+			statLastPayload.Store(string(b[:n]))
 			if rng.Float64() >= *flagSampleRate {
 				continue
 			}
+			statForwarded.Add(1)
 			d := make([]byte, n)
 			copy(d, b)
 			es.SendEventMessage(d)


### PR DESCRIPTION
## Summary

Adds a lightweight `/stats` HTTP endpoint (next to `/healthz` and `/stream`) so we can tell — straight from the DNS endpoint — whether UDP events from getsentry are actually reaching the orbital server. This is to diagnose the empty live.sentry.io globe.

## What it reports

`GET /stats` returns JSON:

| field | meaning |
|---|---|
| `udp_received` | packets read off the UDP socket (pre-sample) |
| `forwarded` | packets forwarded to SSE clients (post-sample) |
| `sample_rate` | current `-sample-rate` |
| `last_recv_unix` / `seconds_since_recv` | freshness of the last packet |
| `last_payload` | raw bytes of the last event (to verify payload shape) |

## How this helps

The key question is whether the break is upstream or downstream of orbital:

- **`udp_received` stays 0** → getsentry's UDP isn't arriving (wrong/stale address, black hole, or not being sent). Break is **upstream**.
- **`udp_received` climbs but the globe is empty** → orbital receives events → break is **downstream** (sampling / SSE / frontend), and `last_payload` shows exactly what's arriving so we can check decode/shape.

## Implementation

- Counters use `sync/atomic`, updated in the UDP read loop.
- No behavior change to `/stream`, `/healthz`, or the UDP forwarding path.

## Testing

Built and ran locally in `-test` mode; `/stats` returns valid JSON and counters increment, e.g.:

```json
{"udp_received":5789,"forwarded":2859,"sample_rate":0.5,"last_recv_unix":1784662338,"seconds_since_recv":0,"last_payload":"[10.6280,106.5152,1784662338767,\"node\"]"}
```

## Usage after deploy

```
curl -s http://orbital-http.default.svc.cluster.local:7000/stats
```