### PR TITLE
revert: remove /stats diagnostic endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
 	"math/rand"
 	"net"
 	"net/http"
-	"sync/atomic"
 	"time"
 
 	sentry "github.com/getsentry/sentry-go"
@@ -27,34 +25,6 @@ var (
 func handleHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("ok"))
-}
-
-// Diagnostic counters for /stats, to understand where events are being lost
-// (e.g. whether UDP packets from getsentry are reaching this server at all).
-var (
-	statUDPReceived  atomic.Uint64 // packets read off the UDP socket (pre-sample)
-	statForwarded    atomic.Uint64 // packets forwarded to SSE clients (post-sample)
-	statLastRecvUnix atomic.Int64  // unix seconds of the last UDP packet received
-	statLastPayload  atomic.Value  // string: last raw payload seen
-)
-
-func handleStats(w http.ResponseWriter, r *http.Request) {
-	last, _ := statLastPayload.Load().(string)
-	lastRecv := statLastRecvUnix.Load()
-	secondsSinceRecv := int64(-1)
-	if lastRecv > 0 {
-		secondsSinceRecv = time.Now().Unix() - lastRecv
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]any{
-		"udp_received":       statUDPReceived.Load(),
-		"forwarded":          statForwarded.Load(),
-		"sample_rate":        *flagSampleRate,
-		"last_recv_unix":     lastRecv,
-		"seconds_since_recv": secondsSinceRecv,
-		"last_payload":       last,
-	})
 }
 
 func runTest(port int) {
@@ -246,7 +216,6 @@ func main() {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", handleHealth)
-	mux.HandleFunc("/stats", handleStats)
 	mux.Handle("/stream", es)
 	// Serve the Vite-built frontend from static/
 	mux.Handle("/", http.FileServer(http.Dir("static")))
@@ -282,13 +251,9 @@ func main() {
 				log.Fatal(err)
 				return
 			}
-			statUDPReceived.Add(1)
-			statLastRecvUnix.Store(time.Now().Unix())
-			statLastPayload.Store(string(b[:n]))
 			if rng.Float64() >= *flagSampleRate {
 				continue
 			}
-			statForwarded.Add(1)
 			d := make([]byte, n)
 			copy(d, b)
 			es.SendEventMessage(d)


### PR DESCRIPTION
Reverts #27.

The `/stats` endpoint was added to diagnose the empty globe on live.sentry.io by exposing UDP ingest counters. It served its purpose — the `/stats` output confirmed UDP packets are reaching the server (627 received) and being forwarded, so the Go backend is healthy. Now that the diagnostic data has been collected, this reverts the temporary instrumentation to keep the server surface minimal.

Restores `main.go` to its pre-#27 state (`healthz` + `stream` only).